### PR TITLE
✨ Add file watching for Endpoint Explorer

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,6 +103,25 @@ export async function activate(context: vscode.ExtensionContext) {
   const apps = await discoverFastAPIApps(parserService)
   const endpointProvider = new EndpointTreeProvider(apps)
 
+  let refreshTimeout: NodeJS.Timeout | null = null
+
+  const triggerRefresh = () => {
+    if (refreshTimeout) {
+      clearTimeout(refreshTimeout)
+    }
+    refreshTimeout = setTimeout(async () => {
+      const newApps = await discoverFastAPIApps(parserService)
+      endpointProvider.setApps(newApps)
+    }, 500) // Debounce for 500ms
+  }
+
+  // Watch for changes in Python files to refresh endpoints
+  const watcher = vscode.workspace.createFileSystemWatcher("**/*.py")
+  watcher.onDidChange(triggerRefresh)
+  watcher.onDidCreate(triggerRefresh)
+  watcher.onDidDelete(triggerRefresh)
+  context.subscriptions.push(watcher)
+
   const treeView = vscode.window.createTreeView("endpoint-explorer", {
     treeDataProvider: endpointProvider,
   })


### PR DESCRIPTION
Needs https://github.com/fastapi/fastapi-vscode/pull/2 
Closes https://github.com/fastapilabs/cloud/issues/2516

This PR makes it so that the extension to automatically pick up any changes you're making to your app so the tree view is never out of date (we still have the refresh button as a backup...we may opt to remove it later).

Review order:
 - #2 
- #3 ⬅️  (you're here!)
- #8 