### PR TITLE
✨ Add Report Issue command in Command Palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
       {
         "command": "fastapi-vscode.copyRouterPrefix",
         "title": "Copy Prefix"
+      },
+      {
+        "command": "fastapi-vscode.reportIssue",
+        "title": "Report Issue...",
+        "category": "FastAPI"
       }
     ],
     "menus": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,6 +73,14 @@ export function activate(context: vscode.ExtensionContext) {
         }
       },
     ),
+
+    vscode.commands.registerCommand("fastapi-vscode.reportIssue", () => {
+      vscode.env.openExternal(
+        vscode.Uri.parse(
+          "https://github.com/fastapi/fastapi-vscode/issues/new?labels=bug",
+        ),
+      )
+    }),
   )
 }
 


### PR DESCRIPTION
Closes https://github.com/fastapilabs/cloud/issues/2530

This PR adds "FastAPI: Report Issue..." to the command palette to quickly open https://github.com/fastapi/fastapi-vscode/issues/new?labels=bug to file an issue. This is a common pattern in extensions (see Python VS Code, Pylance etc).
