### PR TITLE
🐛  Add `matchOnDescription` to allow function name searching

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -437,6 +437,7 @@ function registerCommands(
 
         const selected = await vscode.window.showQuickPick(items, {
           placeHolder: "Search FastAPI endpoints...",
+          matchOnDescription: true,
         })
         trackSearchExecuted(items.length, selected !== undefined)
         if (selected) {


### PR DESCRIPTION
Closes #50 

A fun one-line change! See https://code.visualstudio.com/api/references/vscode-api#QuickPickOptions

<img width="765" height="324" alt="Screenshot 2026-02-17 at 11 22 23 AM" src="https://github.com/user-attachments/assets/8ac1362e-4ab4-4603-a9f7-5f7c745cac3f" />
