### PR TITLE
🔨  fix: detect routes defined on APIRouter instances and add tests fo…

### DIFF
--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -63,7 +63,8 @@ async function findAllFastAPIFiles(
     )
       continue
     const content = await vscode.workspace.fs.readFile(uri)
-    if (new TextDecoder().decode(content).includes("FastAPI(")) {
+    const text = new TextDecoder().decode(content)
+    if (text.includes("FastAPI(") || text.includes("APIRouter(")) {
       results.push(uri.toString())
     }
   }

--- a/src/test/core/routerResolver.test.ts
+++ b/src/test/core/routerResolver.test.ts
@@ -517,5 +517,28 @@ suite("routerResolver", () => {
         "neon router should have routes",
       )
     })
+
+    test("builds graph from standalone APIRouter-only file", async () => {
+      const result = await buildRouterGraph(
+        fixtures.routerOnly.mainPy,
+        parser,
+        fixtures.routerOnly.root,
+        nodeFileSystem,
+      )
+
+      assert.ok(result, "Should find router in APIRouter-only file")
+      assert.strictEqual(result.type, "APIRouter")
+      assert.strictEqual(result.variableName, "router")
+      assert.strictEqual(result.prefix, "/api")
+
+      // Should have 2 routes: GET /items and POST /items
+      assert.strictEqual(result.routes.length, 2)
+      const getPaths = result.routes.map((r) => `${r.method} ${r.path}`)
+      assert.ok(getPaths.includes("get /items"), "Should have GET /items route")
+      assert.ok(
+        getPaths.includes("post /items"),
+        "Should have POST /items route",
+      )
+    })
   })
 })

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -65,6 +65,10 @@ export const fixtures = {
     root: uri(join(fixturesPath, "error-cases")),
     mainPy: uri(join(fixturesPath, "error-cases", "main.py")),
   },
+  routerOnly: {
+    root: uri(join(fixturesPath, "router-only")),
+    mainPy: uri(join(fixturesPath, "router-only", "main.py")),
+  },
   nestedRouter: {
     root: uri(join(fixturesPath, "nested-router")),
     mainPy: uri(join(fixturesPath, "nested-router", "app", "main.py")),


### PR DESCRIPTION
Fixes #85

## Problem
The workspace scanner (`findAllFastAPIFiles` in `appDiscovery.ts`) pre-filters files by checking for `"FastAPI("` to avoid running tree-sitter on every Python  file. This meant router-only files (using `APIRouter()` without a `FastAPI()`  instance) were silently skipped, which is the standard pattern in larger FastAPI  projects.

## Fix

Extended the text pre-filter to also match `"APIRouter("`:
```diff
- if (new TextDecoder().decode(content).includes("FastAPI(")) {
+ const text = new TextDecoder().decode(content)
+ if (text.includes("FastAPI(") || text.includes("APIRouter(")) {
```
The core parsing pipeline already fully supports `APIRouter` , no other changes needed.

## Testing
- Added `router-only` fixture (standalone `APIRouter()`, no `FastAPI()`)
- Added test `"builds graph from standalone APIRouter-only file"` in `routerResolver.test.ts`
- All 425 tests passing ✅

## Before / After

> A real FastAPI project - routers were invisible before, fully discovered after.

### Before:
<img width="1035" height="1073" alt="Untitled-2025-11-26-2202" src="https://github.com/user-attachments/assets/3e8ebe5e-e06a-4bfa-83aa-5f5ee01e83ed" />

### After:
<img width="1038" height="1046" alt="Untitled-2025-11-26-2202 (2)" src="https://github.com/user-attachments/assets/5c17786f-d198-4311-b975-01ef2bbac248" />

---