### PR TITLE
🐛  Prevent activation failure when workspace files are unreadable

### DIFF
--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -66,6 +66,7 @@ async function findAllFastAPIFiles(
     try {
       content = await vscode.workspace.fs.readFile(uri)
     } catch {
+      log(`Skipping unreadable file: ${uri.toString()}`)
       continue
     }
     if (new TextDecoder().decode(content).includes("FastAPI(")) {


### PR DESCRIPTION
This ensures that we gracefully skip any files that might ephemerally exist during activation instead of aborting app discovery and then tracking an activation failure.