### PR TITLE
fix: handle aliased fastapi.FastAPI and fastapi.APIRouter imports

### DIFF
--- a/src/core/extractors.ts
+++ b/src/core/extractors.ts
@@ -459,7 +459,9 @@ export function collectRecognizedNames(nodesByType: Map<string, Node[]>): {
       if (named.name === "fastapi") {
         fastAPINames.add(`${named.alias}.FastAPI`)
         apiRouterNames.add(`${named.alias}.APIRouter`)
-      }
+      } else if (named.name === "fastapi.FastAPI") fastAPINames.add(named.alias)
+      else if (named.name === "fastapi.APIRouter")
+        apiRouterNames.add(named.alias)
     }
   }
 


### PR DESCRIPTION
This fixes #116 

Added `fastapi.FastAPI` and `fastapi.APIRouter` to `collectRecognizedNames()` method in `import_statement` node type.