### PR TITLE
📈 Fix telemetry overcounting and reduce event volume

### DIFF
--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -241,7 +241,13 @@ export async function discoverFastAPIApps(
       stats.folders_with_apps++
     }
 
-    stats[`detection_method_${detectionMethod}`]++
+    if (detectionMethod === "config") {
+      stats.detection_method_config++
+    } else if (detectionMethod === "pyproject") {
+      stats.detection_method_pyproject++
+    } else {
+      stats.detection_method_heuristic++
+    }
   }
 
   if (apps.length === 0) {

--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -10,13 +10,19 @@ import type { Parser } from "./core/parser"
 import { findProjectRoot, uriPath } from "./core/pathUtils"
 import { buildRouterGraph } from "./core/routerResolver"
 import { routerNodeToAppDefinition } from "./core/transformer"
-import { collectRoutes, countRouters } from "./core/treeUtils"
+import { collectRoutes } from "./core/treeUtils"
 import type { AppDefinition } from "./core/types"
 import { log } from "./utils/logger"
-import { createTimer, trackEntrypointDetected } from "./utils/telemetry"
 import { vscodeFileSystem } from "./vscode/vscodeFileSystem"
 
 export type { EntryPoint }
+
+export interface DiscoveryStats {
+  detection_method_config: number
+  detection_method_pyproject: number
+  detection_method_heuristic: number
+  folders_with_apps: number
+}
 
 /**
  * Parses an entrypoint string in module:variable notation.
@@ -137,12 +143,18 @@ async function parsePyprojectForEntryPoint(
  */
 export async function discoverFastAPIApps(
   parser: Parser,
-  trackTelemetry = false,
-): Promise<AppDefinition[]> {
+): Promise<{ apps: AppDefinition[]; stats: DiscoveryStats }> {
+  const stats: DiscoveryStats = {
+    detection_method_config: 0,
+    detection_method_pyproject: 0,
+    detection_method_heuristic: 0,
+    folders_with_apps: 0,
+  }
+
   const workspaceFolders = vscode.workspace.workspaceFolders
   if (!workspaceFolders) {
     log("No workspace folders found")
-    return []
+    return { apps: [], stats }
   }
 
   log(
@@ -152,7 +164,6 @@ export async function discoverFastAPIApps(
   const apps: AppDefinition[] = []
 
   for (const folder of workspaceFolders) {
-    const folderTimer = createTimer()
     let detectionMethod: "config" | "pyproject" | "heuristic" = "heuristic"
     const folderApps: AppDefinition[] = []
     const config = vscode.workspace.getConfiguration("fastapi", folder.uri)
@@ -222,29 +233,20 @@ export async function discoverFastAPIApps(
       }
     }
 
-    const folderRoutes = collectRoutes(folderApps)
-
     if (folderApps.length > 0) {
+      const folderRoutes = collectRoutes(folderApps)
       log(
         `Found ${folderApps.length} FastAPI app(s) with ${folderRoutes.length} route(s) in ${folder.name}`,
       )
+      stats.folders_with_apps++
     }
 
-    // Track entrypoint detection per workspace folder (initial discovery only)
-    if (trackTelemetry) {
-      trackEntrypointDetected({
-        duration_ms: folderTimer(),
-        method: detectionMethod,
-        success: folderApps.length > 0,
-        routes_count: folderRoutes.length,
-        routers_count: countRouters(folderApps),
-      })
-    }
+    stats[`detection_method_${detectionMethod}`]++
   }
 
   if (apps.length === 0) {
     log("No FastAPI apps found in workspace")
   }
 
-  return apps
+  return { apps, stats }
 }

--- a/src/cloud/auth.ts
+++ b/src/cloud/auth.ts
@@ -74,9 +74,10 @@ export class CloudAuthenticationProvider
     )
   }
 
-  startWatching() {
+  async startWatching() {
     // Poll for auth changes since we can't use fs.watch in browser
     // and VS Code's file watcher doesn't work for files outside workspace
+    this.lastAuthState = await this.hasValidToken()
     this.pollingInterval = setInterval(
       () => this.checkAndFireAuthState(),
       AUTH_POLL_INTERVAL_MS,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@
  */
 
 import * as vscode from "vscode"
-import { discoverFastAPIApps } from "./appDiscovery"
+import { type DiscoveryStats, discoverFastAPIApps } from "./appDiscovery"
 import { ApiService } from "./cloud/api"
 import { AUTH_PROVIDER_ID, CloudAuthenticationProvider } from "./cloud/auth"
 import { LOGS_VIEW_ID, LogsViewProvider } from "./cloud/commands/logs"
@@ -71,7 +71,7 @@ export async function activate(context: vscode.ExtensionContext) {
   await initVSCodeTelemetry(context)
 
   let apps: AppDefinition[] = []
-  let stats: Awaited<ReturnType<typeof discoverFastAPIApps>>["stats"] = {
+  let stats: DiscoveryStats = {
     detection_method_config: 0,
     detection_method_pyproject: 0,
     detection_method_heuristic: 0,
@@ -114,7 +114,9 @@ export async function activate(context: vscode.ExtensionContext) {
 
   try {
     // Discover apps and create providers
-    ;({ apps, stats } = await discoverFastAPIApps(parserService))
+    const result = await discoverFastAPIApps(parserService)
+    apps = result.apps
+    stats = result.stats
   } catch (error) {
     success = false
     trackActivationFailed(error, "discovery")

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -70,7 +70,13 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize telemetry
   await initVSCodeTelemetry(context)
 
-  let apps: Awaited<ReturnType<typeof discoverFastAPIApps>> = []
+  let apps: AppDefinition[] = []
+  let stats: Awaited<ReturnType<typeof discoverFastAPIApps>>["stats"] = {
+    detection_method_config: 0,
+    detection_method_pyproject: 0,
+    detection_method_heuristic: 0,
+    folders_with_apps: 0,
+  }
   let success = true
 
   try {
@@ -108,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   try {
     // Discover apps and create providers
-    apps = await discoverFastAPIApps(parserService, true)
+    ;({ apps, stats } = await discoverFastAPIApps(parserService))
   } catch (error) {
     success = false
     trackActivationFailed(error, "discovery")
@@ -128,6 +134,7 @@ export async function activate(context: vscode.ExtensionContext) {
     routers_count: countRouters(apps),
     apps_count: apps.length,
     workspace_folder_count: vscode.workspace.workspaceFolders?.length ?? 0,
+    ...stats,
   })
 
   // Create grouping function that groups by workspace folder if there are multiple folders
@@ -173,7 +180,7 @@ export async function activate(context: vscode.ExtensionContext) {
     if (refreshTimeout) clearTimeout(refreshTimeout)
     refreshTimeout = setTimeout(async () => {
       if (!parserService) return
-      const newApps = await discoverFastAPIApps(parserService)
+      const { apps: newApps } = await discoverFastAPIApps(parserService)
 
       if (uri) {
         await testIndex.invalidateFile(uri.toString())
@@ -425,7 +432,7 @@ function registerCommands(
       async () => {
         if (!parserService) return
         clearImportCache()
-        const newApps = await discoverFastAPIApps(parserService)
+        const { apps: newApps } = await discoverFastAPIApps(parserService)
         pathOperationProvider.setApps(newApps, groupApps(newApps))
         testToRouteProvider.setApps(newApps)
       },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -236,7 +236,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Auth provider must be registered regardless of workspace,
     // so sign-in works from command palette and Accounts menu in vscode.dev
     const authProvider = new CloudAuthenticationProvider(context, apiService)
-    authProvider.startWatching()
+    await authProvider.startWatching()
 
     context.subscriptions.push(
       { dispose: () => authProvider.dispose() },

--- a/src/test/cloud/auth.test.ts
+++ b/src/test/cloud/auth.test.ts
@@ -568,7 +568,7 @@ suite("cloud/auth", () => {
 
         fsStub.fake.readFile.rejects(new Error("File not found"))
 
-        provider.startWatching()
+        await provider.startWatching()
 
         await clock.tickAsync(3100)
         const callCount = fsStub.fake.readFile.callCount

--- a/src/utils/telemetry/events.ts
+++ b/src/utils/telemetry/events.ts
@@ -1,8 +1,5 @@
 import { client } from "./client"
-import type {
-  ActivationEventProps,
-  EntrypointDetectedEventProps,
-} from "./types"
+import type { ActivationEventProps } from "./types"
 
 export function createTimer(): () => number {
   const start = performance.now()
@@ -13,7 +10,6 @@ export const Events = {
   ACTIVATED: "extension_activated",
   ACTIVATION_FAILED: "extension_activation_failed",
   DEACTIVATED: "extension_deactivated",
-  ENTRYPOINT_DETECTED: "extension_entrypoint_detected",
   CODELENS_CLICKED: "extension_codelens_clicked",
   TREE_VIEW_VISIBLE: "extension_tree_view_visible",
   SEARCH_EXECUTED: "extension_search_executed",
@@ -122,12 +118,6 @@ export function trackActivationFailed(
     error_message: sanitizeError(error),
     stage,
   })
-}
-
-export function trackEntrypointDetected(
-  props: EntrypointDetectedEventProps,
-): void {
-  client.capture(Events.ENTRYPOINT_DETECTED, { ...props })
 }
 
 export function trackTreeViewVisible(): void {

--- a/src/utils/telemetry/events.ts
+++ b/src/utils/telemetry/events.ts
@@ -14,7 +14,6 @@ export const Events = {
   ACTIVATION_FAILED: "extension_activation_failed",
   DEACTIVATED: "extension_deactivated",
   ENTRYPOINT_DETECTED: "extension_entrypoint_detected",
-  CODELENS_PROVIDED: "extension_codelens_provided",
   CODELENS_CLICKED: "extension_codelens_clicked",
   TREE_VIEW_VISIBLE: "extension_tree_view_visible",
   SEARCH_EXECUTED: "extension_search_executed",
@@ -142,19 +141,6 @@ export function trackSearchExecuted(
   client.capture(Events.SEARCH_EXECUTED, {
     results_count: resultsCount,
     selected,
-  })
-}
-
-export function trackCodeLensProvided(
-  testCallsCount: number,
-  matchedCount: number,
-  type: "test" | "route" = "test",
-): void {
-  client.capture(Events.CODELENS_PROVIDED, {
-    type,
-    test_calls_count: testCallsCount,
-    matched_count: matchedCount,
-    match_rate: testCallsCount > 0 ? matchedCount / testCallsCount : 0,
   })
 }
 

--- a/src/utils/telemetry/index.ts
+++ b/src/utils/telemetry/index.ts
@@ -17,7 +17,6 @@ export {
   trackCloudProjectUnlinked,
   trackCloudSignIn,
   trackCloudSignOut,
-  trackCodeLensProvided,
   trackDeactivation,
   trackEntrypointDetected,
   trackSearchExecuted,

--- a/src/utils/telemetry/index.ts
+++ b/src/utils/telemetry/index.ts
@@ -18,14 +18,12 @@ export {
   trackCloudSignIn,
   trackCloudSignOut,
   trackDeactivation,
-  trackEntrypointDetected,
   trackSearchExecuted,
   trackTreeViewVisible,
 } from "./events"
 export type {
   ActivationEventProps,
   ClientInfo,
-  EntrypointDetectedEventProps,
   TelemetryConfig,
 } from "./types"
 export {

--- a/src/utils/telemetry/types.ts
+++ b/src/utils/telemetry/types.ts
@@ -23,12 +23,8 @@ export interface ActivationEventProps {
   routers_count: number
   apps_count: number
   workspace_folder_count: number
-}
-
-export interface EntrypointDetectedEventProps {
-  duration_ms: number
-  method: "config" | "pyproject" | "heuristic"
-  success: boolean
-  routes_count: number
-  routers_count: number
+  detection_method_config: number
+  detection_method_pyproject: number
+  detection_method_heuristic: number
+  folders_with_apps: number
 }

--- a/src/vscode/routeToTestCodeLensProvider.ts
+++ b/src/vscode/routeToTestCodeLensProvider.ts
@@ -12,14 +12,12 @@ import {
 
 import { type AppDefinition, collectRoutes } from "../core"
 import type { RouteDefinition } from "../core/types"
-import { trackCodeLensProvided } from "../utils/telemetry"
 import type { TestCallIndex } from "./testIndex"
 
 export class RouteToTestCodeLensProvider implements CodeLensProvider {
   private cachedRoutes: RouteDefinition[] = []
   private testIndex: TestCallIndex
   private indexListener: Disposable
-  private trackedFiles = new Set<string>()
 
   private _onDidChangeCodeLenses = new EventEmitter<void>()
   readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event
@@ -34,7 +32,6 @@ export class RouteToTestCodeLensProvider implements CodeLensProvider {
 
   setApps(apps: AppDefinition[]): void {
     this.cachedRoutes = collectRoutes(apps)
-    this.trackedFiles.clear()
     this._onDidChangeCodeLenses.fire()
   }
 
@@ -75,11 +72,6 @@ export class RouteToTestCodeLensProvider implements CodeLensProvider {
           ],
         }),
       )
-    }
-
-    if (routes.length > 0 && !this.trackedFiles.has(currentFile)) {
-      this.trackedFiles.add(currentFile)
-      trackCodeLensProvided(routes.length, codeLenses.length, "route")
     }
 
     return codeLenses

--- a/src/vscode/testToRouteCodeLensProvider.ts
+++ b/src/vscode/testToRouteCodeLensProvider.ts
@@ -21,7 +21,6 @@ import {
 } from "../core/pathUtils"
 import { collectRoutes } from "../core/treeUtils"
 import type { AppDefinition, SourceLocation } from "../core/types"
-import { trackCodeLensProvided } from "../utils/telemetry"
 
 export class TestToRouteCodeLensProvider implements CodeLensProvider {
   private apps: AppDefinition[] = []
@@ -30,8 +29,6 @@ export class TestToRouteCodeLensProvider implements CodeLensProvider {
   private _onDidChangeCodeLenses = new EventEmitter<void>()
   readonly onDidChangeCodeLenses = this._onDidChangeCodeLenses.event
 
-  private trackedFiles = new Set<string>()
-
   constructor(parser: Parser, apps: AppDefinition[]) {
     this.parser = parser
     this.apps = apps
@@ -39,7 +36,6 @@ export class TestToRouteCodeLensProvider implements CodeLensProvider {
 
   setApps(apps: AppDefinition[]): void {
     this.apps = apps
-    this.trackedFiles.clear()
     this._onDidChangeCodeLenses.fire()
   }
 
@@ -83,13 +79,6 @@ export class TestToRouteCodeLensProvider implements CodeLensProvider {
           }),
         )
       }
-    }
-
-    // Track once per file per session (first open only, edits won't update the count)
-    const fileKey = document.uri.toString()
-    if (testClientCalls.length > 0 && !this.trackedFiles.has(fileKey)) {
-      this.trackedFiles.add(fileKey)
-      trackCodeLensProvided(testClientCalls.length, codeLenses.length)
     }
 
     return codeLenses


### PR DESCRIPTION
Closes https://github.com/fastapilabs/cloud/issues/3952

This PR fixes a couple things to prevent overcounting of events:
- Previously, we didn't seed the lastAuthState before polling which caused us to fire a spurious extension_cloud_sign_in on every activation for already-signed-in users. Now we seed lastAuthState from the current token state before starting the poll, so only real sign-in transitions fire the event.
- Previously, we were tracking whether we were providing codelens to the user. This event was noisy and ultimately, unused. I've opted to remove it. We still track when a codelens was clicked, which IMO is a better signal anyway.
- Previously, we were tracking whether we were able to detect an entrypoint as a distinct event. This was also pretty noisy due to reloads. Instead, we can fold the detection-method counts (detection_method_config/pyproject/heuristic) and folders_with_apps into extension_activated properties.