### PR TITLE
👷 Setup GH actions workflow to check sources for typos

### DIFF
--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -1,0 +1,22 @@
+name: Check typos
+
+permissions: {}
+
+on: [pull_request]
+
+env:
+  CLICOLOR: 1
+
+jobs:
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - name: Spell Check Repo
+      uses: crate-ci/typos@f8a58b6b53f2279f71eb605f03a4ae4d10608f45 # v1.47.0
+      with:
+        config: ./typos.toml

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,9 @@
 bun run typecheck
 bunx lint-staged
+
+# Soft typos check: run only if the CLI is installed, otherwise skip with a hint.
+if command -v typos >/dev/null 2>&1; then
+  typos
+else
+  echo "[typos] skipping check (CLI not found). Install to enable: brew install typos-cli"
+fi

--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -72,7 +72,7 @@ async function findAllFastAPIFiles(
     try {
       content = await vscode.workspace.fs.readFile(uri)
     } catch {
-      log(`Skipping unreadable file: ${uri.toString()}`)
+      log(`Skiping unreadable file: ${uri.toString()}`)
       continue
     }
     if (new TextDecoder().decode(content).includes("FastAPI(")) {

--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -72,7 +72,7 @@ async function findAllFastAPIFiles(
     try {
       content = await vscode.workspace.fs.readFile(uri)
     } catch {
-      log(`Skiping unreadable file: ${uri.toString()}`)
+      log(`Skipping unreadable file: ${uri.toString()}`)
       continue
     }
     if (new TextDecoder().decode(content).includes("FastAPI(")) {

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,2 @@
+[default.extend-identifiers]
+noInferrableTypes = "noInferrableTypes"


### PR DESCRIPTION
Set up GH actions workflow to catch typos in sources.

In other repos we use it as pre-commit hook (see https://github.com/fastapi/fastapi/pull/15482), but here we don't have prek, so I think GH action will be fine

---

Checked by introducing typo in [9028c1b](https://github.com/fastapi/fastapi-vscode/pull/160/commits/9028c1b1c366d38c95da6a60bab25296a31ea82a):

<img width="506" height="248" alt="image" src="https://github.com/user-attachments/assets/c208cedf-ca8a-49f6-8bce-9876c6c57de9" />

<img width="553" height="269" alt="image" src="https://github.com/user-attachments/assets/231b6959-f73a-4f52-bdc2-dd87a7a51c45" />
