### PR TITLE
⚡Speed up extension activation 

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "fastapi-vscode",
       "dependencies": {
+        "p-map": "^7.0.4",
         "posthog-node": "^5.24.1",
         "tinytar": "^0.1.0",
         "toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -359,6 +359,7 @@
     "typescript": "^6.0.2"
   },
   "dependencies": {
+    "p-map": "^7.0.4",
     "posthog-node": "^5.24.1",
     "tinytar": "^0.1.0",
     "toml": "^3.0.0",

--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -3,6 +3,7 @@
  * Handles finding FastAPI apps via pyproject.toml, VS Code settings, or automatic detection.
  */
 
+import pMap from "p-map"
 import * as toml from "toml"
 import * as vscode from "vscode"
 import type { EntryPoint } from "./core/internal"
@@ -48,6 +49,9 @@ export function parseEntrypointString(value: string): {
  * Uses a cheap text pre-filter to avoid tree-sitter parsing non-app files.
  * Returns URI strings sorted by depth (shallower first).
  */
+// Limit concurrent file reads so large workspaces don't fan out unbounded.
+const READ_CONCURRENCY = 50
+
 async function findAllFastAPIFiles(
   folder: vscode.WorkspaceFolder,
 ): Promise<string[]> {
@@ -59,26 +63,32 @@ async function findAllFastAPIFiles(
     ),
   )
 
-  const results: string[] = []
-  for (const uri of pyFiles) {
+  const toScan = pyFiles.filter((uri) => {
     const fileName = uri.path.split("/").pop() ?? ""
-    if (
+    return !(
       fileName.startsWith("test_") ||
       fileName.endsWith("_test.py") ||
       fileName === "conftest.py"
     )
-      continue
-    let content: Uint8Array
-    try {
-      content = await vscode.workspace.fs.readFile(uri)
-    } catch {
-      log(`Skipping unreadable file: ${uri.toString()}`)
-      continue
-    }
-    if (new TextDecoder().decode(content).includes("FastAPI(")) {
-      results.push(uri.toString())
-    }
-  }
+  })
+
+  const matched = await pMap(
+    toScan,
+    async (uri) => {
+      let content: Uint8Array
+      try {
+        content = await vscode.workspace.fs.readFile(uri)
+      } catch {
+        log(`Skipping unreadable file: ${uri.toString()}`)
+        return null
+      }
+      return new TextDecoder().decode(content).includes("FastAPI(")
+        ? uri.toString()
+        : null
+    },
+    { concurrency: READ_CONCURRENCY },
+  )
+  const results = matched.filter((uri): uri is string => uri !== null)
 
   return results.sort(
     (a, b) => uriPath(a).split("/").length - uriPath(b).split("/").length,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -124,10 +124,13 @@ export async function activate(context: vscode.ExtensionContext) {
   }
 
   // Get actual installed Python and package versions from the active interpreter
-  const installedVersions = await getInstalledVersions(TRACKED_PACKAGES)
-
-  // Set versions on telemetry client so they're included in all events
-  telemetryClient.setVersions(installedVersions)
+  getInstalledVersions(TRACKED_PACKAGES)
+    .then((versions) => {
+      telemetryClient.setVersions(versions)
+    })
+    .catch((error) => {
+      log(`Failed to get installed versions: ${error}`)
+    })
 
   trackActivation({
     duration_ms: elapsed(),


### PR DESCRIPTION
Closes https://github.com/fastapilabs/cloud/issues/4097

This PR improves extension activation latency by:
- Deferring Python/package version detection off the activation critical path (runs in the background; no longer awaited)
- Parallelizing the discovery file scan (reads candidate .py files concurrently via p-map instead of one-at-a-time)

Note that discovery results are unchanged.

In local testing, the discovery file scan is ~5x faster (1.3s → 0.3s on a 3k-file workspace) and far faster on high-latency filesystems (large monorepos, WSL, etc). Combined with deferring version detection, this targets the activation tail seen in telemetry (p95 ≈ 60s, p99 in minutes). 