### PR TITLE
🐛 Exclude .venv and cache dirs from test index scan

### DIFF
--- a/src/appDiscovery.ts
+++ b/src/appDiscovery.ts
@@ -13,6 +13,7 @@ import { buildRouterGraph } from "./core/routerResolver"
 import { routerNodeToAppDefinition } from "./core/transformer"
 import { collectRoutes } from "./core/treeUtils"
 import type { AppDefinition } from "./core/types"
+import { READ_CONCURRENCY } from "./utils/constants"
 import { log } from "./utils/logger"
 import { vscodeFileSystem } from "./vscode/vscodeFileSystem"
 
@@ -49,8 +50,6 @@ export function parseEntrypointString(value: string): {
  * Uses a cheap text pre-filter to avoid tree-sitter parsing non-app files.
  * Returns URI strings sorted by depth (shallower first).
  */
-// Limit concurrent file reads so large workspaces don't fan out unbounded.
-const READ_CONCURRENCY = 50
 
 async function findAllFastAPIFiles(
   folder: vscode.WorkspaceFolder,

--- a/src/test/providers/testIndex.test.ts
+++ b/src/test/providers/testIndex.test.ts
@@ -1,0 +1,43 @@
+import * as assert from "node:assert"
+import { shouldIgnoreTestIndexFile } from "../../vscode/testIndex"
+
+suite("shouldIgnoreTestIndexFile", () => {
+  const ignored = [
+    "file:///project/.venv/lib/python3.13/site-packages/pandas/tests/test_frame.py",
+    "file:///project/venv/lib/python3.12/site-packages/sympy/core/tests/test_expr.py",
+    "file:///project/src/__pycache__/test_cached.py",
+    "file:///project/node_modules/pkg/test_index.py",
+    "file:///project/.git/hooks/test_hook.py",
+    "file:///project/.mypy_cache/test_stale.py",
+    "file:///project/.pytest_cache/test_lastfailed.py",
+  ]
+  for (const uri of ignored) {
+    test(`ignores ${uri}`, () => {
+      assert.strictEqual(shouldIgnoreTestIndexFile(uri), true)
+    })
+  }
+
+  const kept = [
+    "file:///project/tests/test_app.py",
+    "file:///project/test/test_routes.py",
+    "file:///project/src/app/test_main.py",
+    "file:///project/test_smoke.py",
+  ]
+  for (const uri of kept) {
+    test(`keeps ${uri}`, () => {
+      assert.strictEqual(shouldIgnoreTestIndexFile(uri), false)
+    })
+  }
+
+  test("does not match folder names as substrings of other segments", () => {
+    // a folder literally named "myvenv" or "venvtools" should not be excluded
+    assert.strictEqual(
+      shouldIgnoreTestIndexFile("file:///project/myvenv/test_x.py"),
+      false,
+    )
+    assert.strictEqual(
+      shouldIgnoreTestIndexFile("file:///project/venvtools/test_x.py"),
+      false,
+    )
+  })
+})

--- a/src/test/providers/testIndex.test.ts
+++ b/src/test/providers/testIndex.test.ts
@@ -1,5 +1,8 @@
 import * as assert from "node:assert"
-import { shouldIgnoreTestIndexFile } from "../../vscode/testIndex"
+import {
+  isTestFileCandidate,
+  shouldIgnoreTestIndexFile,
+} from "../../vscode/testIndex"
 
 suite("shouldIgnoreTestIndexFile", () => {
   const ignored = [
@@ -40,4 +43,33 @@ suite("shouldIgnoreTestIndexFile", () => {
       false,
     )
   })
+})
+
+suite("isTestFileCandidate", () => {
+  const candidates = [
+    "file:///project/tests/test_app.py",
+    "file:///project/test/routes_test.py",
+    "file:///project/src/app/test_main.py",
+    "file:///project/conftest.py",
+  ]
+  for (const uri of candidates) {
+    test(`accepts ${uri}`, () => {
+      assert.strictEqual(isTestFileCandidate(uri), true)
+    })
+  }
+
+  const nonCandidates = [
+    // "test" appears only in a directory segment, not the file name
+    "file:///project/latest/main.py",
+    "file:///project/contest/handlers.py",
+    // file name has no "test"
+    "file:///project/src/main.py",
+    // not a Python file
+    "file:///project/tests/test_app.txt",
+  ]
+  for (const uri of nonCandidates) {
+    test(`rejects ${uri}`, () => {
+      assert.strictEqual(isTestFileCandidate(uri), false)
+    })
+  }
 })

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Max concurrent workspace file reads. Bounds `pMap` fan-out so large
+ * workspaces don't open thousands of file handles at once. Shared by every
+ * path that scans and reads `.py` files (app discovery, test indexing).
+ */
+export const READ_CONCURRENCY = 50

--- a/src/vscode/testIndex.ts
+++ b/src/vscode/testIndex.ts
@@ -7,9 +7,7 @@ import type { SourceLocation } from "../core/types"
 /**
  * Folders to skip when scanning for test files. Unlike app discovery, this
  * keeps `tests`/`test` directories (we want those) but excludes virtual envs
- * and dependency/cache folders so we don't open vendored test suites under
- * `.venv/site-packages` — opening those files broadcasts DidOpenTextDocument
- * events to Python language servers. See issue #165.
+ * and dependency/cache folders.
  */
 const TEST_INDEX_EXCLUDE_DIRS = [
   ".venv",

--- a/src/vscode/testIndex.ts
+++ b/src/vscode/testIndex.ts
@@ -1,8 +1,10 @@
-import { EventEmitter, workspace } from "vscode"
+import pMap from "p-map"
+import { EventEmitter, Uri, workspace } from "vscode"
 import { findTestClientCalls } from "../core/extractors"
 import type { Parser } from "../core/parser"
 import { pathMatchesPathOperation } from "../core/pathUtils"
 import type { SourceLocation } from "../core/types"
+import { log } from "../utils/logger"
 
 /**
  * Folders to skip when scanning for test files. Unlike app discovery, this
@@ -21,9 +23,27 @@ const TEST_INDEX_EXCLUDE_DIRS = [
 
 const TEST_INDEX_EXCLUDE_GLOB = `**/{${TEST_INDEX_EXCLUDE_DIRS.join(",")}}/**`
 
+// Limit concurrent file reads so large workspaces don't fan out unbounded.
+const READ_CONCURRENCY = 50
+
 export function shouldIgnoreTestIndexFile(fileUri: string): boolean {
   const segments = fileUri.split("/")
   return segments.some((segment) => TEST_INDEX_EXCLUDE_DIRS.includes(segment))
+}
+
+/**
+ * Mirrors the discovery glob (a ".py" file whose name contains "test"). Matching
+ * on the file name rather than the whole URI avoids false positives such as a
+ * "latest/" directory making an unrelated ".py" file look like a test.
+ */
+export function isTestFileCandidate(fileUri: string): boolean {
+  const fileName = fileUri.split("/").pop() ?? ""
+  return fileName.endsWith(".py") && fileName.includes("test")
+}
+
+async function readFileText(uri: Uri): Promise<string> {
+  const bytes = await workspace.fs.readFile(uri)
+  return new TextDecoder().decode(bytes)
 }
 
 export class TestCallIndex {
@@ -46,14 +66,24 @@ export class TestCallIndex {
       "**/*test*.py",
       TEST_INDEX_EXCLUDE_GLOB,
     )
-    for (const file of testFiles) {
-      const document = await workspace.openTextDocument(file)
-      const tree = this.parser.parse(document.getText())
-      if (!tree) continue
+    await pMap(
+      testFiles,
+      async (file) => {
+        let text: string
+        try {
+          text = await readFileText(file)
+        } catch {
+          log(`Skipping unreadable test file: ${file.toString()}`)
+          return
+        }
+        const tree = this.parser.parse(text)
+        if (!tree) return
 
-      const calls = findTestClientCalls(tree.rootNode)
-      this.index.set(file.toString(), calls)
-    }
+        const calls = findTestClientCalls(tree.rootNode)
+        this.index.set(file.toString(), calls)
+      },
+      { concurrency: READ_CONCURRENCY },
+    )
     this._onDidChangeIndex.fire()
   }
 
@@ -79,12 +109,12 @@ export class TestCallIndex {
   }
 
   async invalidateFile(fileUri: string): Promise<void> {
-    if (!fileUri.includes("test") || shouldIgnoreTestIndexFile(fileUri)) {
+    if (!isTestFileCandidate(fileUri) || shouldIgnoreTestIndexFile(fileUri)) {
       return
     }
     try {
-      const document = await workspace.openTextDocument(fileUri)
-      const tree = this.parser.parse(document.getText())
+      const text = await readFileText(Uri.parse(fileUri))
+      const tree = this.parser.parse(text)
       if (!tree) {
         this.index.delete(fileUri)
         return

--- a/src/vscode/testIndex.ts
+++ b/src/vscode/testIndex.ts
@@ -4,6 +4,7 @@ import { findTestClientCalls } from "../core/extractors"
 import type { Parser } from "../core/parser"
 import { pathMatchesPathOperation } from "../core/pathUtils"
 import type { SourceLocation } from "../core/types"
+import { READ_CONCURRENCY } from "../utils/constants"
 import { log } from "../utils/logger"
 
 /**
@@ -22,9 +23,6 @@ const TEST_INDEX_EXCLUDE_DIRS = [
 ]
 
 const TEST_INDEX_EXCLUDE_GLOB = `**/{${TEST_INDEX_EXCLUDE_DIRS.join(",")}}/**`
-
-// Limit concurrent file reads so large workspaces don't fan out unbounded.
-const READ_CONCURRENCY = 50
 
 export function shouldIgnoreTestIndexFile(fileUri: string): boolean {
   const segments = fileUri.split("/")

--- a/src/vscode/testIndex.ts
+++ b/src/vscode/testIndex.ts
@@ -4,6 +4,30 @@ import type { Parser } from "../core/parser"
 import { pathMatchesPathOperation } from "../core/pathUtils"
 import type { SourceLocation } from "../core/types"
 
+/**
+ * Folders to skip when scanning for test files. Unlike app discovery, this
+ * keeps `tests`/`test` directories (we want those) but excludes virtual envs
+ * and dependency/cache folders so we don't open vendored test suites under
+ * `.venv/site-packages` — opening those files broadcasts DidOpenTextDocument
+ * events to Python language servers. See issue #165.
+ */
+const TEST_INDEX_EXCLUDE_DIRS = [
+  ".venv",
+  "venv",
+  "__pycache__",
+  "node_modules",
+  ".git",
+  ".mypy_cache",
+  ".pytest_cache",
+]
+
+const TEST_INDEX_EXCLUDE_GLOB = `**/{${TEST_INDEX_EXCLUDE_DIRS.join(",")}}/**`
+
+export function shouldIgnoreTestIndexFile(fileUri: string): boolean {
+  const segments = fileUri.split("/")
+  return segments.some((segment) => TEST_INDEX_EXCLUDE_DIRS.includes(segment))
+}
+
 export class TestCallIndex {
   private index = new Map<
     string,
@@ -20,7 +44,10 @@ export class TestCallIndex {
 
   async build(): Promise<void> {
     this.index.clear()
-    const testFiles = await workspace.findFiles("**/*test*.py")
+    const testFiles = await workspace.findFiles(
+      "**/*test*.py",
+      TEST_INDEX_EXCLUDE_GLOB,
+    )
     for (const file of testFiles) {
       const document = await workspace.openTextDocument(file)
       const tree = this.parser.parse(document.getText())
@@ -54,7 +81,7 @@ export class TestCallIndex {
   }
 
   async invalidateFile(fileUri: string): Promise<void> {
-    if (!fileUri.includes("test")) {
+    if (!fileUri.includes("test") || shouldIgnoreTestIndexFile(fileUri)) {
       return
     }
     try {


### PR DESCRIPTION
Closes #165 

This PR fixes a bug where we weren't filtering out tests in virtual environments. It also makes indexing a bit more performant by using pMap to parallelize and changes the VS Code API used to `readFile` so we aren't opening files to read them (which is why the reported issue impacted language servers).