### PR TITLE
✅ Assert opened URL by host instead of substring

### DIFF
--- a/src/test/cloud/ui/menus.test.ts
+++ b/src/test/cloud/ui/menus.test.ts
@@ -207,9 +207,8 @@ suite("cloud/ui/menus", () => {
       await handler.showMenu()
 
       assert.ok(openStub.calledOnce)
-      assert.ok(
-        openStub.firstCall.args[0].toString().includes("test-app.example.com"),
-      )
+      const openedUrl = new URL(openStub.firstCall.args[0].toString())
+      assert.strictEqual(openedUrl.host, "test-app.example.com")
     })
 
     test("opens dashboard when dashboard selected", async () => {


### PR DESCRIPTION
Just tightens a weak test assertion