### PR TITLE
♻️  Make logs entitlements aware

### DIFF
--- a/src/cloud/api.ts
+++ b/src/cloud/api.ts
@@ -8,6 +8,7 @@ import type {
   Deployment,
   ListResponse,
   Team,
+  TeamAccess,
   UploadInfo,
   User,
 } from "./types"
@@ -21,6 +22,12 @@ export interface AppLogEntry {
   timestamp: string
   message: string
   level: string
+  timestamp_ns?: string
+}
+
+export interface AppLogsResponse {
+  logs: AppLogEntry[]
+  has_more: boolean
 }
 
 export class StreamLogError extends Error {
@@ -105,6 +112,10 @@ export class ApiService {
     return this.request<Team>(`/teams/${teamId}/`)
   }
 
+  async getTeamAccess(teamId: string): Promise<TeamAccess> {
+    return this.request<TeamAccess>(`/teams/${teamId}/access`)
+  }
+
   async getApps(teamId: string): Promise<App[]> {
     const data = await this.request<ListResponse<App>>(
       `/apps/?team_id=${teamId}`,
@@ -143,6 +154,18 @@ export class ApiService {
 
   async getDeployment(deploymentId: string): Promise<Deployment> {
     return this.request<Deployment>(`/deployments/${deploymentId}`)
+  }
+
+  async getAppLogs(options: {
+    appId: string
+    beforeNs?: string
+    limit?: number
+  }): Promise<AppLogsResponse> {
+    const params = new URLSearchParams()
+    if (options.beforeNs) params.set("before_ns", options.beforeNs)
+    if (options.limit) params.set("limit", String(options.limit))
+    const query = params.size > 0 ? `?${params}` : ""
+    return this.request<AppLogsResponse>(`/apps/${options.appId}/logs${query}`)
   }
 
   async *streamAppLogs(options: {

--- a/src/cloud/commands/logs.ts
+++ b/src/cloud/commands/logs.ts
@@ -22,23 +22,18 @@ const BASE_SINCE_OPTIONS: SinceOption[] = [
   { label: "1 hour", value: "1h" },
   { label: "1 day", value: "1d" },
 ]
+const EXTRA_SINCE_OPTION_DAYS = [7, 14]
 
 function dayOption(days: number): SinceOption {
   return { label: `${days} days`, value: `${days}d` }
 }
 
 export function getSinceOptions(logRetentionDays = 1): SinceOption[] {
-  const options = [...BASE_SINCE_OPTIONS]
   const retentionDays = Math.floor(logRetentionDays)
-  const extraDays = [7, 14].filter((days) => days <= retentionDays)
-  if (retentionDays > 1 && !extraDays.includes(retentionDays)) {
-    extraDays.push(retentionDays)
-  }
-
-  for (const days of extraDays.sort((a, b) => a - b)) {
-    options.push(dayOption(days))
-  }
-  return options
+  const extraOptions = EXTRA_SINCE_OPTION_DAYS.filter(
+    (days) => days <= retentionDays,
+  ).map(dayOption)
+  return [...BASE_SINCE_OPTIONS, ...extraOptions]
 }
 
 function parseSinceMs(since: string): number {
@@ -51,6 +46,23 @@ function parseSinceMs(since: string): number {
   if (unit === "m") return value * 60 * 1000
   if (unit === "h") return value * 60 * 60 * 1000
   return value * 24 * 60 * 60 * 1000
+}
+
+function formatSinceLabel(since: string): string {
+  const match = since.match(/^(\d+)([smhd])$/)
+  if (!match) return since
+
+  const value = Number(match[1])
+  const unit = match[2]
+  const unitLabel =
+    unit === "s"
+      ? "second"
+      : unit === "m"
+        ? "minute"
+        : unit === "h"
+          ? "hour"
+          : "day"
+  return `${value} ${unitLabel}${value === 1 ? "" : "s"}`
 }
 
 // Levels recognized when inferring a log's level from its message prefix.
@@ -106,27 +118,24 @@ export function formatLogEntry(entry: AppLogEntry): AppLogEntry {
   }
 }
 
-function getTimestampMs(entry: AppLogEntry): number {
+function getTimestampEpochMs(entry: AppLogEntry): number {
   const timestampMs = new Date(entry.timestamp).getTime()
   return Number.isNaN(timestampMs) ? 0 : timestampMs
 }
 
-function getCursorNs(entry: AppLogEntry): string | undefined {
+function getPaginationCursorNs(entry: AppLogEntry): string | undefined {
   if (entry.timestamp_ns) return entry.timestamp_ns
-  const timestampMs = getTimestampMs(entry)
+  const timestampMs = getTimestampEpochMs(entry)
   return timestampMs > 0 ? `${timestampMs}000000` : undefined
-}
-
-function currentTimeNs(): string {
-  return `${Date.now()}000000`
 }
 
 interface HistoryState {
   appId: string
   beforeNs: string
-  windowStartMs: number
+  windowStartEpochMs: number
+  rangeLabel: string
   hasOlder: boolean
-  checked: boolean
+  hasLogs: boolean
 }
 
 // --- Webview HTML ---
@@ -138,12 +147,14 @@ function getLevelChipsHtml(): string {
   ).join("\n")
 }
 
+function getSinceOptionHtml(option: SinceOption, selected: boolean): string {
+  const selectedAttr = selected ? " selected" : ""
+  return `<option value="${option.value}"${selectedAttr}>${option.label}</option>`
+}
+
 function getSinceOptionsHtml(): string {
   return getSinceOptions()
-    .map(
-      (o, i) =>
-        `<option value="${o.value}"${i === 0 ? " selected" : ""}>${o.label}</option>`,
-    )
+    .map((option, index) => getSinceOptionHtml(option, index === 0))
     .join("")
 }
 
@@ -190,7 +201,7 @@ export function getWebviewHtml(
 	    <button class="icon-btn" id="clear-btn" title="Clear logs"><svg width="12" height="12" viewBox="0 0 16 16"><path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/><path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/></svg>Clear</button>
 	</div>
 	<div class="history-bar hidden" id="history-bar">
-	    <button class="link-btn" id="load-older-btn" title="Check whether earlier logs exist in the selected range" disabled>Check earlier logs</button>
+	    <button class="link-btn" id="load-older-btn" title="Load earlier logs in the selected range" disabled>Load earlier logs</button>
 	    <span class="history-note hidden" id="history-note"></span>
 	</div>
 	<div id="logs"><span class="status">Click "Start" to stream logs.</span></div>
@@ -297,21 +308,20 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
     await this.updateSinceOptionsForConfig(config)
   }
 
-  private postHistoryState(
-    hasOlder: boolean,
-    loading: boolean,
-    checked = this.historyState?.checked ?? false,
-  ): void {
+  private postHistoryState(options?: {
+    hasOlder?: boolean
+    loading?: boolean
+  }): void {
+    const state = this.historyState
     this.view?.webview.postMessage({
       type: "historyState",
-      hasOlder,
-      loading,
-      checked,
+      hasOlder: options?.hasOlder ?? state?.hasOlder ?? false,
+      loading: options?.loading ?? false,
     })
   }
 
   private updateHistoryCursor(entry: AppLogEntry): void {
-    const cursor = getCursorNs(entry)
+    const cursor = getPaginationCursorNs(entry)
     if (!cursor || !this.historyState) return
     if (BigInt(cursor) < BigInt(this.historyState.beforeNs)) {
       this.historyState.beforeNs = cursor
@@ -322,22 +332,29 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
     logs: AppLogEntry[]
     reachedWindowStart: boolean
   } {
-    const windowStartMs = this.historyState?.windowStartMs ?? 0
+    const windowStartEpochMs = this.historyState?.windowStartEpochMs ?? 0
     let reachedWindowStart = false
     const filteredLogs = logs.filter((entry) => {
-      const timestampMs = getTimestampMs(entry)
-      const inWindow = timestampMs >= windowStartMs
+      const timestampMs = getTimestampEpochMs(entry)
+      const inWindow = timestampMs >= windowStartEpochMs
       if (!inWindow) reachedWindowStart = true
       return inWindow
     })
     return { logs: filteredLogs, reachedWindowStart }
   }
 
+  private getNoOlderLogsText(state: HistoryState): string {
+    if (state.hasLogs) {
+      return `No earlier logs in the last ${state.rangeLabel}.`
+    }
+    return `No logs found in the last ${state.rangeLabel}. Choose a longer range to see older logs.`
+  }
+
   async loadOlderLogs(): Promise<void> {
     if (!this.historyState?.hasOlder) return
     const state = this.historyState
 
-    this.postHistoryState(true, true)
+    this.postHistoryState({ loading: true })
     try {
       const response = await this.apiService.getAppLogs({
         appId: state.appId,
@@ -350,20 +367,20 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
         response.logs,
       )
       if (logs.length > 0) {
-        state.beforeNs = getCursorNs(logs[0]) ?? state.beforeNs
+        state.hasLogs = true
+        state.beforeNs = getPaginationCursorNs(logs[0]) ?? state.beforeNs
         this.view?.webview.postMessage({
           type: "olderLogs",
           entries: logs.map(formatLogEntry),
         })
       }
 
-      state.checked = true
       state.hasOlder = response.has_more && !reachedWindowStart
-      this.postHistoryState(state.hasOlder, false, state.checked)
+      this.postHistoryState()
       if (logs.length === 0 && !state.hasOlder) {
         this.view?.webview.postMessage({
           type: "historyNotice",
-          text: "No earlier logs in this range.",
+          text: this.getNoOlderLogsText(state),
         })
       }
     } catch (error) {
@@ -371,7 +388,7 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
 
       const message = error instanceof Error ? error.message : String(error)
       log(`Failed to load older logs: ${message}`)
-      this.postHistoryState(state.hasOlder, false, state.checked)
+      this.postHistoryState()
       this.view?.webview.postMessage({
         type: "historyNotice",
         text: `Failed to load earlier logs: ${message}`,
@@ -414,17 +431,19 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
 
     const appLabel =
       config.app_slug ?? workspaceRoot.path.split("/").pop() ?? ""
+    const nowEpochMs = Date.now()
     this.historyState = {
       appId,
-      beforeNs: currentTimeNs(),
-      windowStartMs: Date.now() - parseSinceMs(since),
+      beforeNs: `${nowEpochMs}000000`,
+      windowStartEpochMs: nowEpochMs - parseSinceMs(since),
+      rangeLabel: formatSinceLabel(since),
       hasOlder: true,
-      checked: false,
+      hasLogs: false,
     }
 
     if (this.view) {
       this.view.webview.postMessage({ type: "clear" })
-      this.postHistoryState(false, false)
+      this.postHistoryState({ hasOlder: false })
       this.view.webview.postMessage({
         type: "status",
         text: "Connecting to log stream...",
@@ -446,24 +465,24 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
         signal,
       })
 
-      // If no entries arrive quickly, update status so user knows we're connected
       const connectedTimer = setTimeout(() => {
         if (count === 0 && this.view && !signal.aborted) {
           this.view.webview.postMessage({
             type: "status",
             text: "Connected. Waiting for new logs...",
           })
-          this.postHistoryState(this.historyState?.hasOlder ?? false, false)
+          this.postHistoryState()
         }
-      }, 2000)
+      }, 1000)
 
       for await (const entry of logStream) {
         if (count === 0) clearTimeout(connectedTimer)
         if (!this.view) return
         count++
+        if (this.historyState) this.historyState.hasLogs = true
         this.updateHistoryCursor(entry)
         if (count === 1) {
-          this.postHistoryState(this.historyState?.hasOlder ?? false, false)
+          this.postHistoryState()
         }
         this.view.webview.postMessage({
           type: "log",
@@ -482,7 +501,7 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
           text: "Stream ended.",
         })
       }
-      this.postHistoryState(this.historyState?.hasOlder ?? false, false)
+      this.postHistoryState()
     } catch (error) {
       if (signal.aborted) return
       if (error instanceof StreamLogError) {

--- a/src/cloud/commands/logs.ts
+++ b/src/cloud/commands/logs.ts
@@ -3,18 +3,55 @@ import { log } from "../../utils/logger"
 import { trackCloudLogsOpened } from "../../utils/telemetry"
 import { type ApiService, type AppLogEntry, StreamLogError } from "../api"
 import type { ConfigService } from "../config"
+import type { Config } from "../types"
 
 const DEFAULT_TAIL = 100
+const HISTORY_PAGE_SIZE = 500
 export const LOGS_VIEW_ID = "fastapi-cloud-logs"
 
 // --- Log formatting ---
 
-const SINCE_OPTIONS = [
+export interface SinceOption {
+  label: string
+  value: string
+}
+
+const BASE_SINCE_OPTIONS: SinceOption[] = [
   { label: "5 minutes", value: "5m" },
   { label: "30 minutes", value: "30m" },
   { label: "1 hour", value: "1h" },
   { label: "1 day", value: "1d" },
 ]
+
+function dayOption(days: number): SinceOption {
+  return { label: `${days} days`, value: `${days}d` }
+}
+
+export function getSinceOptions(logRetentionDays = 1): SinceOption[] {
+  const options = [...BASE_SINCE_OPTIONS]
+  const retentionDays = Math.floor(logRetentionDays)
+  const extraDays = [7, 14].filter((days) => days <= retentionDays)
+  if (retentionDays > 1 && !extraDays.includes(retentionDays)) {
+    extraDays.push(retentionDays)
+  }
+
+  for (const days of extraDays.sort((a, b) => a - b)) {
+    options.push(dayOption(days))
+  }
+  return options
+}
+
+function parseSinceMs(since: string): number {
+  const match = since.match(/^(\d+)([smhd])$/)
+  if (!match) return 5 * 60 * 1000
+
+  const value = Number(match[1])
+  const unit = match[2]
+  if (unit === "s") return value * 1000
+  if (unit === "m") return value * 60 * 1000
+  if (unit === "h") return value * 60 * 60 * 1000
+  return value * 24 * 60 * 60 * 1000
+}
 
 // Levels recognized when inferring a log's level from its message prefix.
 // Pipe colors for these live in the webview stylesheet, keyed on [data-level].
@@ -64,8 +101,32 @@ export function formatLogEntry(entry: AppLogEntry): AppLogEntry {
   return {
     level,
     timestamp: formatTimestamp(entry.timestamp),
+    timestamp_ns: entry.timestamp_ns,
     message: entry.message,
   }
+}
+
+function getTimestampMs(entry: AppLogEntry): number {
+  const timestampMs = new Date(entry.timestamp).getTime()
+  return Number.isNaN(timestampMs) ? 0 : timestampMs
+}
+
+function getCursorNs(entry: AppLogEntry): string | undefined {
+  if (entry.timestamp_ns) return entry.timestamp_ns
+  const timestampMs = getTimestampMs(entry)
+  return timestampMs > 0 ? `${timestampMs}000000` : undefined
+}
+
+function currentTimeNs(): string {
+  return `${Date.now()}000000`
+}
+
+interface HistoryState {
+  appId: string
+  beforeNs: string
+  windowStartMs: number
+  hasOlder: boolean
+  checked: boolean
 }
 
 // --- Webview HTML ---
@@ -78,10 +139,12 @@ function getLevelChipsHtml(): string {
 }
 
 function getSinceOptionsHtml(): string {
-  return SINCE_OPTIONS.map(
-    (o, i) =>
-      `<option value="${o.value}"${i === 0 ? " selected" : ""}>${o.label}</option>`,
-  ).join("")
+  return getSinceOptions()
+    .map(
+      (o, i) =>
+        `<option value="${o.value}"${i === 0 ? " selected" : ""}>${o.label}</option>`,
+    )
+    .join("")
 }
 
 export function getWebviewHtml(
@@ -102,11 +165,11 @@ export function getWebviewHtml(
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' ${webview.cspSource}; script-src ${webview.cspSource};">
 <link rel="stylesheet" href="${stylesUri}">
 </head>
-<body>
-<div class="toolbar">
-    <select id="since-filter">${getSinceOptionsHtml()}</select>
-    <div class="filter-wrapper">
-        <button class="secondary-btn" id="filter-btn" title="Filter displayed logs">Filter <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M4 6l4 4 4-4z"/></svg></button>
+	<body>
+	<div class="toolbar">
+	    <select id="since-filter">${getSinceOptionsHtml()}</select>
+	    <div class="filter-wrapper">
+	        <button class="secondary-btn" id="filter-btn" title="Filter displayed logs">Filter <svg width="10" height="10" viewBox="0 0 16 16" fill="currentColor"><path d="M4 6l4 4 4-4z"/></svg></button>
         <div class="filter-popup" id="filter-popup">
             <div class="filter-row">
                 <label for="level-list">Log Level</label>
@@ -123,10 +186,14 @@ export function getWebviewHtml(
     </div>
     <button id="stream-btn" title="Start streaming"><span id="stream-label">Start</span></button>
     <span id="app-label"></span>
-    <div class="spacer"></div>
-    <button class="icon-btn" id="clear-btn" title="Clear logs"><svg width="12" height="12" viewBox="0 0 16 16"><path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/><path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/></svg>Clear</button>
-</div>
-<div id="logs"><span class="status">Click "Start" to stream logs.</span></div>
+	    <div class="spacer"></div>
+	    <button class="icon-btn" id="clear-btn" title="Clear logs"><svg width="12" height="12" viewBox="0 0 16 16"><path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5zm3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0V6z"/><path fill-rule="evenodd" d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1v1zM4.118 4L4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4H4.118zM2.5 3V2h11v1h-11z"/></svg>Clear</button>
+	</div>
+	<div class="history-bar hidden" id="history-bar">
+	    <button class="link-btn" id="load-older-btn" title="Check whether earlier logs exist in the selected range" disabled>Check earlier logs</button>
+	    <span class="history-note hidden" id="history-note"></span>
+	</div>
+	<div id="logs"><span class="status">Click "Start" to stream logs.</span></div>
 <script src="${scriptUri}"></script>
 </body>
 </html>`
@@ -135,6 +202,7 @@ export function getWebviewHtml(
 export class LogsViewProvider implements vscode.WebviewViewProvider {
   private view: vscode.WebviewView | undefined
   private activeAbortController: AbortController | undefined
+  private historyState: HistoryState | undefined
 
   constructor(
     private extensionUri: vscode.Uri,
@@ -156,6 +224,7 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
       webviewView.webview,
       this.extensionUri,
     )
+    void this.updateSinceOptions()
 
     webviewView.webview.onDidReceiveMessage(async (msg) => {
       if (msg.type === "startStream") {
@@ -163,6 +232,8 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
         await this.streamLogs({ since, tail: DEFAULT_TAIL })
       } else if (msg.type === "stopStream") {
         this.stopStreaming()
+      } else if (msg.type === "loadOlder") {
+        await this.loadOlderLogs()
       }
     })
 
@@ -204,6 +275,110 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
     return activeFolder
   }
 
+  private async updateSinceOptionsForConfig(config: Config): Promise<void> {
+    try {
+      const access = await this.apiService.getTeamAccess(config.team_id)
+      this.view?.webview.postMessage({
+        type: "sinceOptions",
+        options: getSinceOptions(access.entitlements.log_retention_days),
+      })
+    } catch (err) {
+      log(`Failed to fetch team entitlements: ${err}`)
+    }
+  }
+
+  private async updateSinceOptions(): Promise<void> {
+    const workspaceRoot = await this.resolveWorkspaceFolder()
+    if (!workspaceRoot) return
+
+    const config = await this.configService.getConfig(workspaceRoot)
+    if (!config?.app_id) return
+
+    await this.updateSinceOptionsForConfig(config)
+  }
+
+  private postHistoryState(
+    hasOlder: boolean,
+    loading: boolean,
+    checked = this.historyState?.checked ?? false,
+  ): void {
+    this.view?.webview.postMessage({
+      type: "historyState",
+      hasOlder,
+      loading,
+      checked,
+    })
+  }
+
+  private updateHistoryCursor(entry: AppLogEntry): void {
+    const cursor = getCursorNs(entry)
+    if (!cursor || !this.historyState) return
+    if (BigInt(cursor) < BigInt(this.historyState.beforeNs)) {
+      this.historyState.beforeNs = cursor
+    }
+  }
+
+  private filterLogsWithinWindow(logs: AppLogEntry[]): {
+    logs: AppLogEntry[]
+    reachedWindowStart: boolean
+  } {
+    const windowStartMs = this.historyState?.windowStartMs ?? 0
+    let reachedWindowStart = false
+    const filteredLogs = logs.filter((entry) => {
+      const timestampMs = getTimestampMs(entry)
+      const inWindow = timestampMs >= windowStartMs
+      if (!inWindow) reachedWindowStart = true
+      return inWindow
+    })
+    return { logs: filteredLogs, reachedWindowStart }
+  }
+
+  async loadOlderLogs(): Promise<void> {
+    if (!this.historyState?.hasOlder) return
+    const state = this.historyState
+
+    this.postHistoryState(true, true)
+    try {
+      const response = await this.apiService.getAppLogs({
+        appId: state.appId,
+        beforeNs: state.beforeNs,
+        limit: HISTORY_PAGE_SIZE,
+      })
+      if (this.historyState !== state) return
+
+      const { logs, reachedWindowStart } = this.filterLogsWithinWindow(
+        response.logs,
+      )
+      if (logs.length > 0) {
+        state.beforeNs = getCursorNs(logs[0]) ?? state.beforeNs
+        this.view?.webview.postMessage({
+          type: "olderLogs",
+          entries: logs.map(formatLogEntry),
+        })
+      }
+
+      state.checked = true
+      state.hasOlder = response.has_more && !reachedWindowStart
+      this.postHistoryState(state.hasOlder, false, state.checked)
+      if (logs.length === 0 && !state.hasOlder) {
+        this.view?.webview.postMessage({
+          type: "historyNotice",
+          text: "No earlier logs in this range.",
+        })
+      }
+    } catch (error) {
+      if (this.historyState !== state) return
+
+      const message = error instanceof Error ? error.message : String(error)
+      log(`Failed to load older logs: ${message}`)
+      this.postHistoryState(state.hasOlder, false, state.checked)
+      this.view?.webview.postMessage({
+        type: "historyNotice",
+        text: `Failed to load earlier logs: ${message}`,
+      })
+    }
+  }
+
   async streamLogs(options?: { since?: string; tail?: number }): Promise<void> {
     const workspaceRoot = await this.resolveWorkspaceFolder()
 
@@ -221,6 +396,8 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
       return
     }
 
+    await this.updateSinceOptionsForConfig(config)
+
     const since = options?.since ?? "5m"
     const tail = options?.tail ?? 100
 
@@ -237,9 +414,17 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
 
     const appLabel =
       config.app_slug ?? workspaceRoot.path.split("/").pop() ?? ""
+    this.historyState = {
+      appId,
+      beforeNs: currentTimeNs(),
+      windowStartMs: Date.now() - parseSinceMs(since),
+      hasOlder: true,
+      checked: false,
+    }
 
     if (this.view) {
       this.view.webview.postMessage({ type: "clear" })
+      this.postHistoryState(false, false)
       this.view.webview.postMessage({
         type: "status",
         text: "Connecting to log stream...",
@@ -268,6 +453,7 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
             type: "status",
             text: "Connected. Waiting for new logs...",
           })
+          this.postHistoryState(this.historyState?.hasOlder ?? false, false)
         }
       }, 2000)
 
@@ -275,6 +461,10 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
         if (count === 0) clearTimeout(connectedTimer)
         if (!this.view) return
         count++
+        this.updateHistoryCursor(entry)
+        if (count === 1) {
+          this.postHistoryState(this.historyState?.hasOlder ?? false, false)
+        }
         this.view.webview.postMessage({
           type: "log",
           entry: formatLogEntry(entry),
@@ -292,6 +482,7 @@ export class LogsViewProvider implements vscode.WebviewViewProvider {
           text: "Stream ended.",
         })
       }
+      this.postHistoryState(this.historyState?.hasOlder ?? false, false)
     } catch (error) {
       if (signal.aborted) return
       if (error instanceof StreamLogError) {

--- a/src/cloud/types.ts
+++ b/src/cloud/types.ts
@@ -4,6 +4,24 @@ export interface Team {
   slug: string
 }
 
+export interface Entitlements {
+  max_apps: number
+  max_replicas: number
+  max_custom_domains: number
+  max_seats: number
+  log_retention_days: number
+  metrics_retention_days: number
+  advanced_metrics_enabled: boolean
+}
+
+export interface TeamAccess {
+  role: string
+  is_owner: boolean
+  permissions: string[]
+  assignable_roles?: string[]
+  entitlements: Entitlements
+}
+
 export interface App {
   id: string
   slug: string

--- a/src/cloud/ui/panel/styles.css
+++ b/src/cloud/ui/panel/styles.css
@@ -72,8 +72,63 @@ body {
   background: var(--vscode-button-secondaryHoverBackground, #505050);
 }
 
+.secondary-btn:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.secondary-btn:disabled:hover {
+  background: var(--vscode-button-secondaryBackground, #3c3c3c);
+}
+
 .secondary-btn.active {
   outline: 1px solid var(--vscode-focusBorder, #007fd4);
+}
+
+.history-bar {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 22px;
+  padding: 2px 8px;
+  border-bottom: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.16));
+  color: var(--vscode-descriptionForeground, rgba(128, 128, 128, 0.85));
+  font-size: 0.85em;
+}
+
+.history-bar.hidden {
+  display: none;
+}
+
+.history-note.hidden,
+.link-btn.hidden {
+  display: none;
+}
+
+.link-btn {
+  background: transparent;
+  color: var(--vscode-textLink-foreground, #3794ff);
+  border: none;
+  padding: 0 6px;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+.link-btn:hover {
+  color: var(--vscode-textLink-activeForeground, #3794ff);
+  text-decoration: underline;
+}
+
+.link-btn:disabled {
+  cursor: default;
+  opacity: 0.65;
+  text-decoration: none;
+}
+
+.history-note {
+  font-style: normal;
+  opacity: 0.85;
 }
 
 #app-label {

--- a/src/cloud/ui/panel/webview.ts
+++ b/src/cloud/ui/panel/webview.ts
@@ -10,6 +10,11 @@ interface SinceOption {
   value: string
 }
 
+type HistoryRowState =
+  | { kind: "hidden" }
+  | { kind: "button"; loading: boolean }
+  | { kind: "notice"; text: string }
+
 const vscode = acquireVsCodeApi()
 const logs = document.getElementById("logs")!
 const sinceFilter = document.getElementById("since-filter") as HTMLSelectElement
@@ -27,10 +32,6 @@ const levelList = document.getElementById("level-list")!
 const appLabelEl = document.getElementById("app-label")!
 let firstEntry = true
 let isStreaming = false
-
-function esc(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")
-}
 
 function getSelectedLevels(): string[] {
   return Array.from(
@@ -64,16 +65,13 @@ filterBtn.addEventListener("click", (e) => {
 })
 
 clearBtn.addEventListener("click", () => {
-  logs.innerHTML = ""
+  logs.replaceChildren()
   firstEntry = true
 })
 
 loadOlderBtn.addEventListener("click", () => {
   loadOlderBtn.disabled = true
-  loadOlderBtn.textContent =
-    loadOlderBtn.dataset.checked === "true"
-      ? "Loading earlier logs..."
-      : "Checking earlier logs..."
+  loadOlderBtn.textContent = "Loading logs..."
   vscode.postMessage({ type: "loadOlder" })
 })
 
@@ -150,41 +148,42 @@ function setStreamingState(streaming: boolean, appLabel?: string): void {
     streaming && appLabel ? `Streaming logs for ${appLabel}...` : ""
 }
 
-function setHistoryState(
-  hasOlder: boolean,
-  loading: boolean,
-  checked: boolean,
-): void {
-  historyNote.textContent = ""
-  historyNote.classList.add("hidden")
-  loadOlderBtn.classList.remove("hidden")
-  loadOlderBtn.dataset.checked = checked ? "true" : "false"
-  historyBar.classList.toggle("hidden", !hasOlder && !loading)
-  loadOlderBtn.disabled = !hasOlder || loading
-  if (loading) {
-    loadOlderBtn.textContent = checked
-      ? "Loading earlier logs..."
-      : "Checking earlier logs..."
-  } else {
-    loadOlderBtn.textContent = checked
-      ? "Load earlier logs"
-      : "Check earlier logs"
+function renderHistoryRow(state: HistoryRowState): void {
+  historyBar.classList.toggle("hidden", state.kind === "hidden")
+  loadOlderBtn.classList.toggle("hidden", state.kind !== "button")
+  historyNote.classList.toggle("hidden", state.kind !== "notice")
+
+  if (state.kind === "hidden") {
+    historyNote.textContent = ""
+    return
   }
-  loadOlderBtn.title = checked
-    ? "Load more earlier logs in the selected range"
-    : "Check whether earlier logs exist in the selected range"
+
+  if (state.kind === "notice") {
+    historyNote.textContent = state.text
+    return
+  }
+
+  historyNote.textContent = ""
+  loadOlderBtn.disabled = state.loading
+  loadOlderBtn.textContent = state.loading
+    ? "Loading logs..."
+    : "Load earlier logs"
+  loadOlderBtn.title = "Load earlier logs in the selected range"
+}
+
+function setHistoryState(hasOlder: boolean, loading: boolean): void {
+  renderHistoryRow(
+    hasOlder || loading ? { kind: "button", loading } : { kind: "hidden" },
+  )
 }
 
 function showHistoryNotice(text: string): void {
-  historyBar.classList.remove("hidden")
-  loadOlderBtn.classList.add("hidden")
-  historyNote.textContent = text
-  historyNote.classList.remove("hidden")
+  renderHistoryRow({ kind: "notice", text })
 }
 
 function updateSinceOptions(options: SinceOption[]): void {
   const previousValue = sinceFilter.value
-  sinceFilter.innerHTML = ""
+  sinceFilter.replaceChildren()
   for (const option of options) {
     const optionEl = document.createElement("option")
     optionEl.value = option.value
@@ -213,6 +212,13 @@ function buildLogLine(entry: AppLogEntry): HTMLElement {
   return line
 }
 
+function buildStatusLine(text: string): HTMLElement {
+  const status = document.createElement("div")
+  status.className = "status"
+  status.textContent = text
+  return status
+}
+
 function applyCurrentFilters(line: HTMLElement): void {
   if (!shouldShow(line, getSelectedLevels(), searchInput.value.toLowerCase())) {
     line.classList.add("filtered")
@@ -223,7 +229,7 @@ window.addEventListener("message", (event) => {
   const msg = event.data
   if (msg.type === "log") {
     if (firstEntry) {
-      logs.innerHTML = ""
+      logs.replaceChildren()
       firstEntry = false
     }
     const wasAtBottom = isNearBottom()
@@ -233,9 +239,11 @@ window.addEventListener("message", (event) => {
     if (wasAtBottom) window.scrollTo(0, document.body.scrollHeight)
   } else if (msg.type === "olderLogs" && Array.isArray(msg.entries)) {
     if (firstEntry) {
-      logs.innerHTML = ""
+      logs.replaceChildren()
       firstEntry = false
     }
+    const previousScrollHeight = document.body.scrollHeight
+    const previousScrollY = window.scrollY
     const fragment = document.createDocumentFragment()
     for (const entry of msg.entries) {
       const line = buildLogLine(entry)
@@ -243,15 +251,19 @@ window.addEventListener("message", (event) => {
       fragment.append(line)
     }
     logs.prepend(fragment)
+    window.scrollTo(
+      0,
+      previousScrollY + document.body.scrollHeight - previousScrollHeight,
+    )
   } else if (msg.type === "status") {
-    const safe = esc(msg.text)
+    const status = buildStatusLine(String(msg.text ?? ""))
     if (firstEntry) {
-      logs.innerHTML = `<span class="status">${safe}</span>`
+      logs.replaceChildren(status)
     } else {
-      logs.insertAdjacentHTML("beforeend", `<div class="status">${safe}</div>`)
+      logs.append(status)
     }
   } else if (msg.type === "clear") {
-    logs.innerHTML = ""
+    logs.replaceChildren()
     firstEntry = true
   } else if (msg.type === "streamingState") {
     setStreamingState(msg.streaming, msg.appLabel)
@@ -260,10 +272,6 @@ window.addEventListener("message", (event) => {
   } else if (msg.type === "historyNotice") {
     showHistoryNotice(String(msg.text ?? ""))
   } else if (msg.type === "historyState") {
-    setHistoryState(
-      Boolean(msg.hasOlder),
-      Boolean(msg.loading),
-      Boolean(msg.checked),
-    )
+    setHistoryState(Boolean(msg.hasOlder), Boolean(msg.loading))
   }
 })

--- a/src/cloud/ui/panel/webview.ts
+++ b/src/cloud/ui/panel/webview.ts
@@ -5,11 +5,21 @@ import type { AppLogEntry } from "../../api"
 
 declare function acquireVsCodeApi(): { postMessage(msg: unknown): void }
 
+interface SinceOption {
+  label: string
+  value: string
+}
+
 const vscode = acquireVsCodeApi()
 const logs = document.getElementById("logs")!
 const sinceFilter = document.getElementById("since-filter") as HTMLSelectElement
 const searchInput = document.getElementById("search-input") as HTMLInputElement
 const streamBtn = document.getElementById("stream-btn")!
+const historyBar = document.getElementById("history-bar")!
+const loadOlderBtn = document.getElementById(
+  "load-older-btn",
+) as HTMLButtonElement
+const historyNote = document.getElementById("history-note")!
 const clearBtn = document.getElementById("clear-btn")!
 const filterBtn = document.getElementById("filter-btn")!
 const filterPopup = document.getElementById("filter-popup")!
@@ -56,6 +66,15 @@ filterBtn.addEventListener("click", (e) => {
 clearBtn.addEventListener("click", () => {
   logs.innerHTML = ""
   firstEntry = true
+})
+
+loadOlderBtn.addEventListener("click", () => {
+  loadOlderBtn.disabled = true
+  loadOlderBtn.textContent =
+    loadOlderBtn.dataset.checked === "true"
+      ? "Loading earlier logs..."
+      : "Checking earlier logs..."
+  vscode.postMessage({ type: "loadOlder" })
 })
 
 function isNearBottom(): boolean {
@@ -131,6 +150,53 @@ function setStreamingState(streaming: boolean, appLabel?: string): void {
     streaming && appLabel ? `Streaming logs for ${appLabel}...` : ""
 }
 
+function setHistoryState(
+  hasOlder: boolean,
+  loading: boolean,
+  checked: boolean,
+): void {
+  historyNote.textContent = ""
+  historyNote.classList.add("hidden")
+  loadOlderBtn.classList.remove("hidden")
+  loadOlderBtn.dataset.checked = checked ? "true" : "false"
+  historyBar.classList.toggle("hidden", !hasOlder && !loading)
+  loadOlderBtn.disabled = !hasOlder || loading
+  if (loading) {
+    loadOlderBtn.textContent = checked
+      ? "Loading earlier logs..."
+      : "Checking earlier logs..."
+  } else {
+    loadOlderBtn.textContent = checked
+      ? "Load earlier logs"
+      : "Check earlier logs"
+  }
+  loadOlderBtn.title = checked
+    ? "Load more earlier logs in the selected range"
+    : "Check whether earlier logs exist in the selected range"
+}
+
+function showHistoryNotice(text: string): void {
+  historyBar.classList.remove("hidden")
+  loadOlderBtn.classList.add("hidden")
+  historyNote.textContent = text
+  historyNote.classList.remove("hidden")
+}
+
+function updateSinceOptions(options: SinceOption[]): void {
+  const previousValue = sinceFilter.value
+  sinceFilter.innerHTML = ""
+  for (const option of options) {
+    const optionEl = document.createElement("option")
+    optionEl.value = option.value
+    optionEl.textContent = option.label
+    sinceFilter.append(optionEl)
+  }
+
+  if (options.some((option) => option.value === previousValue)) {
+    sinceFilter.value = previousValue
+  }
+}
+
 // Build the log line as a DOM node. The untrusted message is set as a text
 // node, so it is never parsed as HTML — no sanitization needed.
 function buildLogLine(entry: AppLogEntry): HTMLElement {
@@ -147,6 +213,12 @@ function buildLogLine(entry: AppLogEntry): HTMLElement {
   return line
 }
 
+function applyCurrentFilters(line: HTMLElement): void {
+  if (!shouldShow(line, getSelectedLevels(), searchInput.value.toLowerCase())) {
+    line.classList.add("filtered")
+  }
+}
+
 window.addEventListener("message", (event) => {
   const msg = event.data
   if (msg.type === "log") {
@@ -157,12 +229,20 @@ window.addEventListener("message", (event) => {
     const wasAtBottom = isNearBottom()
     const line = buildLogLine(msg.entry)
     logs.append(line)
-    if (
-      !shouldShow(line, getSelectedLevels(), searchInput.value.toLowerCase())
-    ) {
-      line.classList.add("filtered")
-    }
+    applyCurrentFilters(line)
     if (wasAtBottom) window.scrollTo(0, document.body.scrollHeight)
+  } else if (msg.type === "olderLogs" && Array.isArray(msg.entries)) {
+    if (firstEntry) {
+      logs.innerHTML = ""
+      firstEntry = false
+    }
+    const fragment = document.createDocumentFragment()
+    for (const entry of msg.entries) {
+      const line = buildLogLine(entry)
+      applyCurrentFilters(line)
+      fragment.append(line)
+    }
+    logs.prepend(fragment)
   } else if (msg.type === "status") {
     const safe = esc(msg.text)
     if (firstEntry) {
@@ -175,5 +255,15 @@ window.addEventListener("message", (event) => {
     firstEntry = true
   } else if (msg.type === "streamingState") {
     setStreamingState(msg.streaming, msg.appLabel)
+  } else if (msg.type === "sinceOptions" && Array.isArray(msg.options)) {
+    updateSinceOptions(msg.options)
+  } else if (msg.type === "historyNotice") {
+    showHistoryNotice(String(msg.text ?? ""))
+  } else if (msg.type === "historyState") {
+    setHistoryState(
+      Boolean(msg.hasOlder),
+      Boolean(msg.loading),
+      Boolean(msg.checked),
+    )
   }
 })

--- a/src/test/cloud/api.test.ts
+++ b/src/test/cloud/api.test.ts
@@ -240,6 +240,34 @@ suite("cloud/api", () => {
       assert.strictEqual(teams[0].slug, "team-1")
     })
 
+    test("getTeamAccess returns entitlements", async () => {
+      const fetchStub = sinon.stub(globalThis, "fetch").resolves(
+        mockResponse({
+          role: "owner",
+          is_owner: true,
+          permissions: ["app:write"],
+          entitlements: {
+            max_apps: 25,
+            max_replicas: 100,
+            max_custom_domains: 20,
+            max_seats: 10,
+            log_retention_days: 14,
+            metrics_retention_days: 14,
+            advanced_metrics_enabled: true,
+          },
+        }),
+      )
+
+      const access = await api.getTeamAccess("team-id")
+
+      assert.strictEqual(
+        fetchStub.firstCall.args[0],
+        `${DEFAULT_BASE_URL}/teams/team-id/access`,
+      )
+      assert.strictEqual(access.entitlements.log_retention_days, 14)
+      assert.strictEqual(access.entitlements.advanced_metrics_enabled, true)
+    })
+
     test("throws when not authenticated", async () => {
       mockSession(null)
 
@@ -300,6 +328,35 @@ suite("cloud/api", () => {
 
       assert.strictEqual(apps.length, 1)
       assert.strictEqual(apps[0].slug, "app-1")
+    })
+
+    test("getAppLogs requests paginated logs", async () => {
+      const fetchStub = sinon.stub(globalThis, "fetch").resolves(
+        mockResponse({
+          logs: [
+            {
+              timestamp: "2025-01-15T10:30:00Z",
+              timestamp_ns: "1736937000000000000",
+              message: "line 1",
+              level: "info",
+            },
+          ],
+          has_more: true,
+        }),
+      )
+
+      const response = await api.getAppLogs({
+        appId: "app-id",
+        beforeNs: "1736937001000000000",
+        limit: 500,
+      })
+
+      assert.strictEqual(
+        fetchStub.firstCall.args[0],
+        `${DEFAULT_BASE_URL}/apps/app-id/logs?before_ns=1736937001000000000&limit=500`,
+      )
+      assert.strictEqual(response.logs.length, 1)
+      assert.strictEqual(response.has_more, true)
     })
 
     test("createApp sends POST", async () => {

--- a/src/test/cloud/commands/logs.test.ts
+++ b/src/test/cloud/commands/logs.test.ts
@@ -14,6 +14,13 @@ import { mockApiService, mockConfigService } from "../../testUtils"
 const testWorkspaceUri = vscode.Uri.file("/tmp/test")
 const testExtensionUri = vscode.Uri.file("/tmp/extension")
 
+interface TestLogEntry {
+  timestamp: string
+  timestamp_ns: string
+  message: string
+  level: string
+}
+
 function createWebviewView() {
   const messages: any[] = []
   const messageHandlers: ((msg: any) => void)[] = []
@@ -66,6 +73,18 @@ function createProvider(
   )
 
   return { provider, configService, apiService }
+}
+
+function createLogEntry(
+  timestamp: string,
+  timestamp_ns: string,
+  message: string,
+): TestLogEntry {
+  return { timestamp, timestamp_ns, message, level: "info" }
+}
+
+async function* streamEntries(entries: TestLogEntry[]) {
+  for (const entry of entries) yield entry
 }
 
 suite("cloud/commands/logs", () => {
@@ -181,6 +200,50 @@ suite("cloud/commands/logs", () => {
       assert.ok(statusMessages.some((m) => m.text.includes("No logs found")))
     })
 
+    test("enables manual older log loading when the initial stream stays empty", async () => {
+      const clock = sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      let releaseStream: (() => void) | undefined
+      async function* delayedStream() {
+        await new Promise<void>((resolve) => {
+          releaseStream = resolve
+        })
+        yield createLogEntry(
+          "2025-01-15T10:35:00Z",
+          "1736937300000000000",
+          "eventual log",
+        )
+      }
+      apiService.streamAppLogs.returns(delayedStream())
+      apiService.getAppLogs.resolves({
+        logs: [],
+        has_more: false,
+      })
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      const streamPromise = provider.streamLogs({ since: "30m" })
+      await Promise.resolve()
+      await Promise.resolve()
+      await clock.tickAsync(1000)
+
+      assert.strictEqual(apiService.getAppLogs.called, false)
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyState" &&
+            m.hasOlder === true &&
+            m.loading === false,
+        ),
+      )
+
+      releaseStream?.()
+      await streamPromise
+    })
+
     test("handles StreamLogError", async () => {
       const { provider, configService, apiService } = createProvider()
       const { view, messages } = createWebviewView()
@@ -293,15 +356,15 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* fakeStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "line 1",
-          level: "info",
-        }
-      }
-      apiService.streamAppLogs.returns(fakeStream())
+      apiService.streamAppLogs.returns(
+        streamEntries([
+          createLogEntry(
+            "2025-01-15T10:30:00Z",
+            "1736937000000000000",
+            "line 1",
+          ),
+        ]),
+      )
       sinon.stub(vscode.commands, "executeCommand").resolves()
 
       await provider.streamLogs({ since: "1h" })
@@ -311,8 +374,7 @@ suite("cloud/commands/logs", () => {
           (m) =>
             m.type === "historyState" &&
             m.hasOlder === true &&
-            m.loading === false &&
-            m.checked === false,
+            m.loading === false,
         ),
       )
     })
@@ -324,23 +386,22 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* fakeStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "newer",
-          level: "info",
-        }
-      }
-      apiService.streamAppLogs.returns(fakeStream())
+      apiService.streamAppLogs.returns(
+        streamEntries([
+          createLogEntry(
+            "2025-01-15T10:30:00Z",
+            "1736937000000000000",
+            "newer",
+          ),
+        ]),
+      )
       apiService.getAppLogs.resolves({
         logs: [
-          {
-            timestamp: "2025-01-15T10:20:00Z",
-            timestamp_ns: "1736936400000000000",
-            message: "older",
-            level: "info",
-          },
+          createLogEntry(
+            "2025-01-15T10:20:00Z",
+            "1736936400000000000",
+            "older",
+          ),
         ],
         has_more: false,
       })
@@ -362,8 +423,7 @@ suite("cloud/commands/logs", () => {
           (m) =>
             m.type === "historyState" &&
             m.hasOlder === false &&
-            m.loading === false &&
-            m.checked === true,
+            m.loading === false,
         ),
       )
     })
@@ -375,23 +435,22 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* fakeStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "newer",
-          level: "info",
-        }
-      }
-      apiService.streamAppLogs.returns(fakeStream())
+      apiService.streamAppLogs.returns(
+        streamEntries([
+          createLogEntry(
+            "2025-01-15T10:30:00Z",
+            "1736937000000000000",
+            "newer",
+          ),
+        ]),
+      )
       apiService.getAppLogs.resolves({
         logs: [
-          {
-            timestamp: "2025-01-15T10:20:00Z",
-            timestamp_ns: "1736936400000000000",
-            message: "older",
-            level: "info",
-          },
+          createLogEntry(
+            "2025-01-15T10:20:00Z",
+            "1736936400000000000",
+            "older",
+          ),
         ],
         has_more: true,
       })
@@ -405,8 +464,7 @@ suite("cloud/commands/logs", () => {
           (m) =>
             m.type === "historyState" &&
             m.hasOlder === true &&
-            m.loading === false &&
-            m.checked === true,
+            m.loading === false,
         ),
       )
     })
@@ -418,23 +476,22 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* fakeStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "newer",
-          level: "info",
-        }
-      }
-      apiService.streamAppLogs.returns(fakeStream())
+      apiService.streamAppLogs.returns(
+        streamEntries([
+          createLogEntry(
+            "2025-01-15T10:30:00Z",
+            "1736937000000000000",
+            "newer",
+          ),
+        ]),
+      )
       apiService.getAppLogs.resolves({
         logs: [
-          {
-            timestamp: "2025-01-15T10:00:00Z",
-            timestamp_ns: "1736935200000000000",
-            message: "too old",
-            level: "info",
-          },
+          createLogEntry(
+            "2025-01-15T10:00:00Z",
+            "1736935200000000000",
+            "too old",
+          ),
         ],
         has_more: true,
       })
@@ -448,7 +505,7 @@ suite("cloud/commands/logs", () => {
         messages.some(
           (m) =>
             m.type === "historyNotice" &&
-            m.text === "No earlier logs in this range.",
+            m.text === "No earlier logs in the last 30 minutes.",
         ),
       )
       assert.ok(
@@ -467,6 +524,41 @@ suite("cloud/commands/logs", () => {
       )
     })
 
+    test("suggests choosing a longer range when no loaded logs are in the selected range", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* emptyStream() {}
+      apiService.streamAppLogs.returns(emptyStream())
+      apiService.getAppLogs.resolves({
+        logs: [
+          createLogEntry(
+            "2025-01-15T10:00:00Z",
+            "1736935200000000000",
+            "outside selected range",
+          ),
+        ],
+        has_more: true,
+      })
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "30m" })
+      await provider.loadOlderLogs()
+
+      assert.ok(!messages.some((m) => m.type === "olderLogs"))
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyNotice" &&
+            m.text ===
+              "No logs found in the last 30 minutes. Choose a longer range to see older logs.",
+        ),
+      )
+    })
+
     test("ignores older log responses after a new stream starts", async () => {
       sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
       const { provider, configService, apiService } = createProvider()
@@ -474,49 +566,38 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* firstStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "first stream",
-          level: "info",
-        }
-      }
-
-      async function* secondStream() {
-        yield {
-          timestamp: "2025-01-15T10:35:00Z",
-          timestamp_ns: "1736937300000000000",
-          message: "second stream",
-          level: "info",
-        }
-      }
-
       let resolveOlderLogs:
-        | ((response: {
-            logs: {
-              timestamp: string
-              timestamp_ns: string
-              message: string
-              level: string
-            }[]
-            has_more: boolean
-          }) => void)
+        | ((response: { logs: TestLogEntry[]; has_more: boolean }) => void)
         | undefined
       const olderLogsPromise = new Promise<{
-        logs: {
-          timestamp: string
-          timestamp_ns: string
-          message: string
-          level: string
-        }[]
+        logs: TestLogEntry[]
         has_more: boolean
       }>((resolve) => {
         resolveOlderLogs = resolve
       })
 
-      apiService.streamAppLogs.onFirstCall().returns(firstStream())
-      apiService.streamAppLogs.onSecondCall().returns(secondStream())
+      apiService.streamAppLogs
+        .onFirstCall()
+        .returns(
+          streamEntries([
+            createLogEntry(
+              "2025-01-15T10:30:00Z",
+              "1736937000000000000",
+              "first stream",
+            ),
+          ]),
+        )
+      apiService.streamAppLogs
+        .onSecondCall()
+        .returns(
+          streamEntries([
+            createLogEntry(
+              "2025-01-15T10:35:00Z",
+              "1736937300000000000",
+              "second stream",
+            ),
+          ]),
+        )
       apiService.getAppLogs.returns(olderLogsPromise)
       sinon.stub(vscode.commands, "executeCommand").resolves()
 
@@ -526,12 +607,11 @@ suite("cloud/commands/logs", () => {
 
       resolveOlderLogs?.({
         logs: [
-          {
-            timestamp: "2025-01-15T10:20:00Z",
-            timestamp_ns: "1736936400000000000",
-            message: "stale older",
-            level: "info",
-          },
+          createLogEntry(
+            "2025-01-15T10:20:00Z",
+            "1736936400000000000",
+            "stale older",
+          ),
         ],
         has_more: false,
       })
@@ -555,16 +635,15 @@ suite("cloud/commands/logs", () => {
       provider.resolveWebviewView(view)
       configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
 
-      async function* fakeStream() {
-        yield {
-          timestamp: "2025-01-15T10:30:00Z",
-          timestamp_ns: "1736937000000000000",
-          message: "newer",
-          level: "info",
-        }
-      }
-
-      apiService.streamAppLogs.returns(fakeStream())
+      apiService.streamAppLogs.returns(
+        streamEntries([
+          createLogEntry(
+            "2025-01-15T10:30:00Z",
+            "1736937000000000000",
+            "newer",
+          ),
+        ]),
+      )
       apiService.getAppLogs.rejects(new Error("network failed"))
       sinon.stub(vscode.commands, "executeCommand").resolves()
 
@@ -863,7 +942,7 @@ suite("cloud/commands/logs", () => {
       assert.ok(html.includes('id="since-filter"'))
       assert.ok(html.includes('id="load-older-btn"'))
       assert.ok(html.includes('id="history-note"'))
-      assert.ok(html.includes("Check earlier logs"))
+      assert.ok(html.includes("Load earlier logs"))
       assert.ok(html.includes('id="stream-btn"'))
       assert.ok(html.includes('id="filter-btn"'))
       assert.ok(html.includes('id="clear-btn"'))

--- a/src/test/cloud/commands/logs.test.ts
+++ b/src/test/cloud/commands/logs.test.ts
@@ -201,7 +201,10 @@ suite("cloud/commands/logs", () => {
     })
 
     test("enables manual older log loading when the initial stream stays empty", async () => {
-      const clock = sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const clock = sinon.useFakeTimers({
+        now: new Date("2025-01-15T10:40:00Z"),
+        shouldClearNativeTimers: true,
+      })
       const { provider, configService, apiService } = createProvider()
       const { view, messages } = createWebviewView()
       provider.resolveWebviewView(view)

--- a/src/test/cloud/commands/logs.test.ts
+++ b/src/test/cloud/commands/logs.test.ts
@@ -4,6 +4,7 @@ import * as vscode from "vscode"
 import { StreamLogError } from "../../../cloud/api"
 import {
   formatLogEntry,
+  getSinceOptions,
   getWebviewHtml,
   LogsViewProvider,
 } from "../../../cloud/commands/logs"
@@ -69,6 +70,22 @@ function createProvider(
 
 suite("cloud/commands/logs", () => {
   teardown(() => sinon.restore())
+
+  suite("getSinceOptions", () => {
+    test("limits hobby teams to the base retention options", () => {
+      assert.deepStrictEqual(
+        getSinceOptions(1).map((option) => option.value),
+        ["5m", "30m", "1h", "1d"],
+      )
+    })
+
+    test("includes weekly and full-retention options for pro teams", () => {
+      assert.deepStrictEqual(
+        getSinceOptions(14).map((option) => option.value),
+        ["5m", "30m", "1h", "1d", "7d", "14d"],
+      )
+    })
+  })
 
   suite("resolveWebviewView", () => {
     test("sets up webview options and html", () => {
@@ -267,6 +284,299 @@ suite("cloud/commands/logs", () => {
       assert.strictEqual(opts.since, "1d")
       assert.strictEqual(opts.tail, 200)
       assert.strictEqual(opts.follow, true)
+    })
+
+    test("enables older log loading after stream cursor is available", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* fakeStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "line 1",
+          level: "info",
+        }
+      }
+      apiService.streamAppLogs.returns(fakeStream())
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "1h" })
+
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyState" &&
+            m.hasOlder === true &&
+            m.loading === false &&
+            m.checked === false,
+        ),
+      )
+    })
+
+    test("loads older logs before the oldest current cursor", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* fakeStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "newer",
+          level: "info",
+        }
+      }
+      apiService.streamAppLogs.returns(fakeStream())
+      apiService.getAppLogs.resolves({
+        logs: [
+          {
+            timestamp: "2025-01-15T10:20:00Z",
+            timestamp_ns: "1736936400000000000",
+            message: "older",
+            level: "info",
+          },
+        ],
+        has_more: false,
+      })
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "1h" })
+      await provider.loadOlderLogs()
+
+      assert.deepStrictEqual(apiService.getAppLogs.firstCall.args[0], {
+        appId: "a1",
+        beforeNs: "1736937000000000000",
+        limit: 500,
+      })
+      const olderMessages = messages.filter((m) => m.type === "olderLogs")
+      assert.strictEqual(olderMessages.length, 1)
+      assert.strictEqual(olderMessages[0].entries[0].message, "older")
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyState" &&
+            m.hasOlder === false &&
+            m.loading === false &&
+            m.checked === true,
+        ),
+      )
+    })
+
+    test("keeps loading available as a load action after history confirms more pages", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* fakeStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "newer",
+          level: "info",
+        }
+      }
+      apiService.streamAppLogs.returns(fakeStream())
+      apiService.getAppLogs.resolves({
+        logs: [
+          {
+            timestamp: "2025-01-15T10:20:00Z",
+            timestamp_ns: "1736936400000000000",
+            message: "older",
+            level: "info",
+          },
+        ],
+        has_more: true,
+      })
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "1h" })
+      await provider.loadOlderLogs()
+
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyState" &&
+            m.hasOlder === true &&
+            m.loading === false &&
+            m.checked === true,
+        ),
+      )
+    })
+
+    test("does not render older logs outside selected range", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* fakeStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "newer",
+          level: "info",
+        }
+      }
+      apiService.streamAppLogs.returns(fakeStream())
+      apiService.getAppLogs.resolves({
+        logs: [
+          {
+            timestamp: "2025-01-15T10:00:00Z",
+            timestamp_ns: "1736935200000000000",
+            message: "too old",
+            level: "info",
+          },
+        ],
+        has_more: true,
+      })
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "30m" })
+      await provider.loadOlderLogs()
+
+      assert.ok(!messages.some((m) => m.type === "olderLogs"))
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyNotice" &&
+            m.text === "No earlier logs in this range.",
+        ),
+      )
+      assert.ok(
+        !messages.some(
+          (m) =>
+            m.type === "status" && m.text === "No older logs in this range.",
+        ),
+      )
+      assert.ok(
+        messages.some(
+          (m) =>
+            m.type === "historyState" &&
+            m.hasOlder === false &&
+            m.loading === false,
+        ),
+      )
+    })
+
+    test("ignores older log responses after a new stream starts", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* firstStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "first stream",
+          level: "info",
+        }
+      }
+
+      async function* secondStream() {
+        yield {
+          timestamp: "2025-01-15T10:35:00Z",
+          timestamp_ns: "1736937300000000000",
+          message: "second stream",
+          level: "info",
+        }
+      }
+
+      let resolveOlderLogs:
+        | ((response: {
+            logs: {
+              timestamp: string
+              timestamp_ns: string
+              message: string
+              level: string
+            }[]
+            has_more: boolean
+          }) => void)
+        | undefined
+      const olderLogsPromise = new Promise<{
+        logs: {
+          timestamp: string
+          timestamp_ns: string
+          message: string
+          level: string
+        }[]
+        has_more: boolean
+      }>((resolve) => {
+        resolveOlderLogs = resolve
+      })
+
+      apiService.streamAppLogs.onFirstCall().returns(firstStream())
+      apiService.streamAppLogs.onSecondCall().returns(secondStream())
+      apiService.getAppLogs.returns(olderLogsPromise)
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "1h" })
+      const loadPromise = provider.loadOlderLogs()
+      await provider.streamLogs({ since: "5m" })
+
+      resolveOlderLogs?.({
+        logs: [
+          {
+            timestamp: "2025-01-15T10:20:00Z",
+            timestamp_ns: "1736936400000000000",
+            message: "stale older",
+            level: "info",
+          },
+        ],
+        has_more: false,
+      })
+      await loadPromise
+
+      assert.ok(
+        !messages.some(
+          (m) =>
+            m.type === "olderLogs" &&
+            m.entries.some((entry: { message: string }) =>
+              entry.message.includes("stale older"),
+            ),
+        ),
+      )
+    })
+
+    test("keeps older log fetch errors visible after restoring history state", async () => {
+      sinon.useFakeTimers(new Date("2025-01-15T10:40:00Z"))
+      const { provider, configService, apiService } = createProvider()
+      const { view, messages } = createWebviewView()
+      provider.resolveWebviewView(view)
+      configService.getConfig.resolves({ app_id: "a1", team_id: "t1" })
+
+      async function* fakeStream() {
+        yield {
+          timestamp: "2025-01-15T10:30:00Z",
+          timestamp_ns: "1736937000000000000",
+          message: "newer",
+          level: "info",
+        }
+      }
+
+      apiService.streamAppLogs.returns(fakeStream())
+      apiService.getAppLogs.rejects(new Error("network failed"))
+      sinon.stub(vscode.commands, "executeCommand").resolves()
+
+      await provider.streamLogs({ since: "1h" })
+      await provider.loadOlderLogs()
+
+      const historyMessages = messages.filter(
+        (m) => m.type === "historyState" || m.type === "historyNotice",
+      )
+      const lastHistoryMessage = historyMessages.at(-1)
+      assert.strictEqual(lastHistoryMessage?.type, "historyNotice")
+      assert.ok(lastHistoryMessage?.text.includes("network failed"))
     })
   })
 
@@ -548,9 +858,12 @@ suite("cloud/commands/logs", () => {
       assert.ok(html.includes("https://test-csp-source"))
     })
 
-    test("includes toolbar controls", () => {
+    test("includes log controls", () => {
       const html = getWebviewHtml(createMockWebview(), testExtensionUri)
       assert.ok(html.includes('id="since-filter"'))
+      assert.ok(html.includes('id="load-older-btn"'))
+      assert.ok(html.includes('id="history-note"'))
+      assert.ok(html.includes("Check earlier logs"))
       assert.ok(html.includes('id="stream-btn"'))
       assert.ok(html.includes('id="filter-btn"'))
       assert.ok(html.includes('id="clear-btn"'))

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -201,6 +201,21 @@ export function mockApiService(
   stub.getUser.resolves(null)
   stub.getTeams.resolves([])
   stub.getApps.resolves([])
+  stub.getAppLogs.resolves({ logs: [], has_more: false })
+  stub.getTeamAccess.resolves({
+    role: "owner",
+    is_owner: true,
+    permissions: [],
+    entitlements: {
+      max_apps: 3,
+      max_replicas: 3,
+      max_custom_domains: 1,
+      max_seats: 1,
+      log_retention_days: 1,
+      metrics_retention_days: 1,
+      advanced_metrics_enabled: false,
+    },
+  })
 
   Object.assign(stub, overrides)
   return stub


### PR DESCRIPTION
Closes https://github.com/fastapilabs/cloud/issues/4268

This makes the VS Code extension aware of FastAPI Cloud log-retention entitlements, so Pro subscribers can select longer log ranges like 7 days and 14 days directly in the editor.

It also adds a manual “Load earlier logs” flow for noisy or high-traffic apps, allowing users to page in older log lines when the initial streamed tail is limited to 100 lines.