### PR TITLE
🐛 Keep @types/vscode at the engines.vscode floor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,10 @@ updates:
       default-days: 7
     commit-message:
       prefix: ⬆
+    # @types/vscode must stay at or below engines.vscode, otherwise vsce
+    # refuses to package the extension.
+    ignore:
+      - dependency-name: "@types/vscode"
     groups:
       npm-packages:
         dependency-type: "development"
@@ -39,6 +43,10 @@ updates:
       default-days: 7
     commit-message:
       prefix: ⬆
+    # @types/vscode must stay at or below engines.vscode, otherwise vsce
+    # refuses to package the extension.
+    ignore:
+      - dependency-name: "@types/vscode"
     groups:
       bun-packages:
         patterns:

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@types/bun": "latest",
         "@types/mocha": "^10.0.10",
         "@types/sinon": "^22.0.0",
-        "@types/vscode": "^1.125.0",
+        "@types/vscode": "^1.95.0",
         "@vscode/test-cli": "^0.0.15",
         "@vscode/test-electron": "^3.0.0",
         "@vscode/vsce": "^3.9.2",
@@ -254,7 +254,7 @@
 
     "@types/sinonjs__fake-timers": ["@types/sinonjs__fake-timers@15.0.1", "", {}, "sha512-Ko2tjWJq8oozHzHV+reuvS5KYIRAokHnGbDwGh/J64LntgpbuylF74ipEL24HCyRjf9FOlBiBHWBR1RlVKsI1w=="],
 
-    "@types/vscode": ["@types/vscode@1.125.0", "", {}, "sha512-0icm/ZQAaism87P0ekHqi4/Ju9du+Tm0RUW+y7vqRsxY2cY0FNRX1nAnaW7nT6npPt2tfHiheZ55Zm9UhqonFA=="],
+    "@types/vscode": ["@types/vscode@1.95.0", "", {}, "sha512-0LBD8TEiNbet3NvWsmn59zLzOFu/txSlGxnv5yAFHCrhG9WvAnR3IvfHzMOs2aeWqgvNjq9pO99IUw8d3n+unw=="],
 
     "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
 

--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "@types/bun": "latest",
     "@types/mocha": "^10.0.10",
     "@types/sinon": "^22.0.0",
-    "@types/vscode": "^1.125.0",
+    "@types/vscode": "^1.95.0",
     "@vscode/test-cli": "^0.0.15",
     "@vscode/test-electron": "^3.0.0",
     "@vscode/vsce": "^3.9.2",


### PR DESCRIPTION
On trying to release 0.3.0, publishing failed because @types/vscode had been bumped to a version greater than engines.vscode, which made vsce refuse to package the extension (the types shouldn't outrank the engine).

This reverts the bump and adds a dependabot ignore for that package, since it isn't really a dep we need to keep current; it's the declaration of the oldest VS Code we support. Raising it is a deliberate decision, paired with a matching engines.vscode bump. In the future we bump it and engines.vscode intentionally, together.