### PR TITLE
🔐 Use PR Submit for pull requests

### DIFF
--- a/.github/pr-submit.yml
+++ b/.github/pr-submit.yml
@@ -1,0 +1,2 @@
+workflows:
+  - .github/workflows/prepare-release.yml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -23,14 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          token: ${{ secrets.FASTAPI_VSCODE_LATEST_CHANGES }} # zizmor: ignore[secrets-outside-env]
-          persist-credentials: true
+          persist-credentials: false
       - name: Prepare release
         env:
           BUMP: ${{ inputs.bump }}
@@ -42,18 +40,22 @@ jobs:
           set -euo pipefail
           version="$(node scripts/prepare-release.mjs current-version)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Get PR Submit token
+        id: pr-submit
+        uses: tiangolo/pr-submit@d802fdf59bde80bc3eb8bd3259f4cbeec63de4aa # 0.0.1
       - name: Create release pull request
         env:
-          GH_TOKEN: ${{ secrets.FASTAPI_VSCODE_LATEST_CHANGES }}
+          GH_TOKEN: ${{ steps.pr-submit.outputs.token }}
           VERSION: ${{ steps.release-version.outputs.version }}
         run: |
           set -euo pipefail
           branch="release-${VERSION}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "pr-submit[bot]"
+          git config user.email "pr-submit[bot]@users.noreply.github.com"
           git switch -c "$branch"
           git add package.json CHANGELOG.md
           git commit -m "🔖 Release version ${VERSION}"
+          gh auth setup-git
           git push --set-upstream origin "$branch"
           gh pr create \
             --base main \


### PR DESCRIPTION
Replace the long-lived personal access token used by workflows that create pull requests with a short-lived repository-scoped token from PR Submit.

The workflows now request the token through GitHub OIDC, check out without persisted credentials, authenticate Git with `gh auth setup-git`, and attribute commits to `pr-submit[bot]`. The repository allowlist includes only the migrated workflows.

Validated with YAML parsing, `git diff --check`, and an online zizmor audit.

## AI Disclaimer

Created with gpt-5.6-sol and reviewed by hand.
