### PR TITLE
🐛 Discover routes from imported custom APIRouter instances

### DIFF
--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -5,10 +5,10 @@
 import type { Tree } from "web-tree-sitter"
 import { logError } from "../utils/logger"
 import {
+  callAssignmentExtractor,
   collectRecognizedNames,
   collectStringVariables,
   decoratorExtractor,
-  factoryCallExtractor,
   getNodesByType,
   importExtractor,
   includeRouterExtractor,
@@ -44,12 +44,11 @@ export function analyzeTree(tree: Tree, filePath: string): FileAnalysis {
   const decoratedDefs = nodesByType.get("decorated_definition") ?? []
   const routes = decoratedDefs.flatMap(decoratorExtractor)
 
-  // Get all router assignments
+  // Get module-level call assignments and recognized router assignments
   const assignments = nodesByType.get("assignment") ?? []
   const { fastAPINames, apiRouterNames } = collectRecognizedNames(nodesByType)
-  const knownConstructors = new Set([...fastAPINames, ...apiRouterNames])
-  const factoryCalls = assignments
-    .map((node) => factoryCallExtractor(node, knownConstructors))
+  const callAssignments = assignments
+    .map(callAssignmentExtractor)
     .filter(notNull)
   const routers = assignments
     .map((node) => routerExtractor(node, apiRouterNames, fastAPINames))
@@ -89,7 +88,7 @@ export function analyzeTree(tree: Tree, filePath: string): FileAnalysis {
     includeRouters,
     mounts,
     imports,
-    factoryCalls,
+    callAssignments,
   }
 }
 

--- a/src/core/analyzer.ts
+++ b/src/core/analyzer.ts
@@ -68,17 +68,11 @@ export function analyzeTree(tree: Tree, filePath: string): FileAnalysis {
 
   const stringVariables = collectStringVariables(nodesByType)
 
-  for (const route of routes) {
-    route.path = resolveVariables(route.path, stringVariables)
+  for (const item of [...routes, ...mounts]) {
+    item.path = resolveVariables(item.path, stringVariables)
   }
-  for (const router of routers) {
-    router.prefix = resolveVariables(router.prefix, stringVariables)
-  }
-  for (const ir of includeRouters) {
-    ir.prefix = resolveVariables(ir.prefix, stringVariables)
-  }
-  for (const mount of mounts) {
-    mount.path = resolveVariables(mount.path, stringVariables)
+  for (const item of [...routers, ...callAssignments, ...includeRouters]) {
+    item.prefix = resolveVariables(item.prefix, stringVariables)
   }
 
   return {

--- a/src/core/extractors.ts
+++ b/src/core/extractors.ts
@@ -4,7 +4,7 @@
 
 import type { Node } from "web-tree-sitter"
 import type {
-  FactoryCallInfo,
+  CallAssignmentInfo,
   ImportedName,
   ImportInfo,
   IncludeRouterInfo,
@@ -601,10 +601,7 @@ export function mountExtractor(node: Node): MountInfo | null {
   }
 }
 
-export function factoryCallExtractor(
-  node: Node,
-  knownConstructors: Set<string>,
-): FactoryCallInfo | null {
+export function callAssignmentExtractor(node: Node): CallAssignmentInfo | null {
   if (node.type !== "assignment") {
     return null
   }
@@ -620,11 +617,6 @@ export function factoryCallExtractor(
     return null
   }
 
-  const functionName = functionNode.text
-  if (knownConstructors.has(functionName)) {
-    return null
-  }
-
   // Skip function and class-local variables to avoid false positives
   if (
     hasAncestor(node, "function_definition") ||
@@ -635,7 +627,9 @@ export function factoryCallExtractor(
 
   return {
     variableName: variableNameNode.text,
-    functionName: functionName,
+    callee: functionNode.text,
+    line: node.startPosition.row + 1,
+    column: node.startPosition.column,
   }
 }
 

--- a/src/core/extractors.ts
+++ b/src/core/extractors.ts
@@ -265,6 +265,30 @@ function extractTags(listNode: Node): string[] {
     .filter((v): v is string => v !== null)
 }
 
+function extractRouterCallMetadata(callNode: Node): {
+  prefix: string
+  tags: string[]
+} {
+  let prefix = ""
+  let tags: string[] = []
+  const argumentsNode = callNode.childForFieldName("arguments")
+  for (const child of argumentsNode?.namedChildren ?? []) {
+    if (child.type !== "keyword_argument") {
+      continue
+    }
+    const argName = child.childForFieldName("name")?.text
+    const argValue = child.childForFieldName("value")
+
+    if (argName === "prefix" && argValue) {
+      prefix = extractPathFromNode(argValue)
+    } else if (argName === "tags" && argValue?.type === "list") {
+      tags = extractTags(argValue)
+    }
+  }
+
+  return { prefix, tags }
+}
+
 export function routerExtractor(
   node: Node,
   apiRouterNames?: Set<string>,
@@ -298,22 +322,7 @@ export function routerExtractor(
     return null
   }
 
-  let prefix = ""
-  let tags: string[] = []
-  const argumentsNode = valueNode.childForFieldName("arguments")
-  for (const child of argumentsNode?.namedChildren ?? []) {
-    if (child.type !== "keyword_argument") {
-      continue
-    }
-    const argName = child.childForFieldName("name")?.text
-    const argValue = child.childForFieldName("value")
-
-    if (argName === "prefix" && argValue) {
-      prefix = extractPathFromNode(argValue)
-    } else if (argName === "tags" && argValue?.type === "list") {
-      tags = extractTags(argValue)
-    }
-  }
+  const { prefix, tags } = extractRouterCallMetadata(valueNode)
 
   return {
     variableName: variableNameNode.text,
@@ -625,9 +634,13 @@ export function callAssignmentExtractor(node: Node): CallAssignmentInfo | null {
     return null
   }
 
+  const { prefix, tags } = extractRouterCallMetadata(valueNode)
+
   return {
     variableName: variableNameNode.text,
     callee: functionNode.text,
+    prefix,
+    tags,
     line: node.startPosition.row + 1,
     column: node.startPosition.column,
   }

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -81,6 +81,8 @@ export interface MountInfo {
 export interface CallAssignmentInfo {
   variableName: string
   callee: string
+  prefix: string
+  tags: string[]
   line: number
   column: number
 }

--- a/src/core/internal.ts
+++ b/src/core/internal.ts
@@ -78,9 +78,11 @@ export interface MountInfo {
   app: string
 }
 
-export interface FactoryCallInfo {
+export interface CallAssignmentInfo {
   variableName: string
-  functionName: string
+  callee: string
+  line: number
+  column: number
 }
 
 export interface FileAnalysis {
@@ -90,7 +92,7 @@ export interface FileAnalysis {
   includeRouters: IncludeRouterInfo[]
   mounts: MountInfo[]
   imports: ImportInfo[]
-  factoryCalls: FactoryCallInfo[]
+  callAssignments: CallAssignmentInfo[]
 }
 
 export interface RouterNode {

--- a/src/core/routerResolver.ts
+++ b/src/core/routerResolver.ts
@@ -62,8 +62,8 @@ function inferIncludedRouter(
   return {
     variableName: assignment.variableName,
     type: "APIRouter",
-    prefix: "",
-    tags: [],
+    prefix: assignment.prefix,
+    tags: assignment.tags,
     line: assignment.line,
     column: assignment.column,
   }

--- a/src/core/routerResolver.ts
+++ b/src/core/routerResolver.ts
@@ -19,6 +19,17 @@ interface ResolutionContext {
   visited: Set<string>
 }
 
+interface ResolveReferenceOptions {
+  reference: string
+  analysis: FileAnalysis
+  currentFileUri: string
+  ctx: ResolutionContext
+}
+
+interface InternalResolveReferenceOptions extends ResolveReferenceOptions {
+  kind: "includedRouter" | "mountedApp"
+}
+
 /**
  * Finds the main FastAPI app or APIRouter in the list of routers.
  * If targetVariable is specified, only returns the router with that variable name.
@@ -35,6 +46,27 @@ function findAppRouter(
     routers.find((r) => r.type === "FastAPI") ??
     routers.find((r) => r.type === "APIRouter")
   )
+}
+
+function inferIncludedRouter(
+  analysis: FileAnalysis,
+  variableName: string,
+): RouterInfo | undefined {
+  const assignment = analysis.callAssignments.find(
+    (candidate) => candidate.variableName === variableName,
+  )
+  if (!assignment) {
+    return undefined
+  }
+
+  return {
+    variableName: assignment.variableName,
+    type: "APIRouter",
+    prefix: "",
+    tags: [],
+    line: assignment.line,
+    column: assignment.column,
+  }
 }
 
 function createRouterNode(
@@ -55,6 +87,14 @@ function createRouterNode(
   }
 }
 
+function resolveIncludedRouter(options: ResolveReferenceOptions) {
+  return resolveReference({ ...options, kind: "includedRouter" })
+}
+
+function resolveMountedApp(options: ResolveReferenceOptions) {
+  return resolveReference({ ...options, kind: "mountedApp" })
+}
+
 async function processIncludeRouters(
   analysis: FileAnalysis,
   ownerRouter: RouterNode,
@@ -68,12 +108,12 @@ async function processIncludeRouters(
     log(
       `Resolving include_router: ${include.router} (prefix: ${include.prefix || "none"})`,
     )
-    const childRouter = await resolveRouterReference(
-      include.router,
+    const childRouter = await resolveIncludedRouter({
+      reference: include.router,
       analysis,
       currentFileUri,
       ctx,
-    )
+    })
     if (childRouter) {
       // Merge tags from include_router call with the router's own tags
       if (include.tags.length > 0) {
@@ -198,18 +238,18 @@ async function buildRouterGraphInternal(
   // `app = FastAPI()` and `app.include_router(...)` inside `create_app` are visible
   // when analyzing the factory file directly.
   if (!appRouter && targetVariable) {
-    const factoryCall = analysis.factoryCalls.find(
-      (fc) => fc.variableName === targetVariable,
+    const callAssignment = analysis.callAssignments.find(
+      (assignment) => assignment.variableName === targetVariable,
     )
-    if (factoryCall) {
+    if (callAssignment) {
       const matchingImport = analysis.imports.find((imp) =>
-        imp.names.includes(factoryCall.functionName),
+        imp.names.includes(callAssignment.callee),
       )
       if (matchingImport) {
         const namedImport = matchingImport.namedImports.find(
-          (ni) => (ni.alias ?? ni.name) === factoryCall.functionName,
+          (ni) => (ni.alias ?? ni.name) === callAssignment.callee,
         )
-        const originalName = namedImport?.name ?? factoryCall.functionName
+        const originalName = namedImport?.name ?? callAssignment.callee
         const factoryFileUri = await resolveNamedImport(
           {
             modulePath: matchingImport.modulePath,
@@ -252,12 +292,12 @@ async function buildRouterGraphInternal(
 
   // Process mount() calls for subapps
   for (const mount of analysis.mounts) {
-    const childRouter = await resolveRouterReference(
-      mount.app,
+    const childRouter = await resolveMountedApp({
+      reference: mount.app,
       analysis,
-      resolvedEntryUri,
+      currentFileUri: resolvedEntryUri,
       ctx,
-    )
+    })
     if (childRouter) {
       rootRouter.children.push({
         router: childRouter,
@@ -277,12 +317,13 @@ async function buildRouterGraphInternal(
  * Handles both simple references (e.g., "router") and dotted references
  * (e.g., "api_routes.router" where api_routes is an imported module).
  */
-async function resolveRouterReference(
-  reference: string,
-  analysis: FileAnalysis,
-  currentFileUri: string,
-  ctx: ResolutionContext,
-): Promise<RouterNode | null> {
+async function resolveReference({
+  reference,
+  analysis,
+  currentFileUri,
+  ctx,
+  kind,
+}: InternalResolveReferenceOptions): Promise<RouterNode | null> {
   const { projectRootUri, parser, fs, visited } = ctx
   const parts = reference.split(".")
   const moduleName = parts[0]
@@ -358,9 +399,13 @@ async function resolveRouterReference(
     }
 
     // Find the router with the matching variable name
-    const targetRouter = importedAnalysis.routers.find(
-      (r) => r.variableName === attributeName,
-    )
+    const targetRouter =
+      importedAnalysis.routers.find(
+        (router) => router.variableName === attributeName,
+      ) ??
+      (kind === "includedRouter"
+        ? inferIncludedRouter(importedAnalysis, attributeName)
+        : undefined)
     if (targetRouter) {
       const visitedKey = `${importedFileUri}#${attributeName}`
 

--- a/src/test/core/analyzer.test.ts
+++ b/src/test/core/analyzer.test.ts
@@ -70,7 +70,7 @@ from auth.testing_router import ProtectedRouter
 def build_router():
     local_router = ProtectedRouter()
 
-router = ProtectedRouter()
+router = ProtectedRouter(prefix="/protected", tags=["protected"])
 `
       const tree = parse(code)
       const result = analyzeTree(tree, "/test/file.py")
@@ -80,6 +80,8 @@ router = ProtectedRouter()
         {
           variableName: "router",
           callee: "ProtectedRouter",
+          prefix: "/protected",
+          tags: ["protected"],
           line: 7,
           column: 0,
         },

--- a/src/test/core/analyzer.test.ts
+++ b/src/test/core/analyzer.test.ts
@@ -63,6 +63,29 @@ router = APIRouter(prefix="/api")
       assert.strictEqual(result.routers[1].prefix, "/api")
     })
 
+    test("records module-level direct call assignments as neutral facts", () => {
+      const code = `
+from auth.testing_router import ProtectedRouter
+
+def build_router():
+    local_router = ProtectedRouter()
+
+router = ProtectedRouter()
+`
+      const tree = parse(code)
+      const result = analyzeTree(tree, "/test/file.py")
+
+      assert.strictEqual(result.routers.length, 0)
+      assert.deepStrictEqual(result.callAssignments, [
+        {
+          variableName: "router",
+          callee: "ProtectedRouter",
+          line: 7,
+          column: 0,
+        },
+      ])
+    })
+
     test("extracts include_router calls", () => {
       const code = `
 app.include_router(users.router, prefix="/users")

--- a/src/test/core/routerResolver.test.ts
+++ b/src/test/core/routerResolver.test.ts
@@ -2,6 +2,7 @@ import * as assert from "node:assert"
 import { Parser } from "../../core/parser"
 import { findProjectRoot } from "../../core/pathUtils"
 import { buildRouterGraph } from "../../core/routerResolver"
+import { routerNodeToAppDefinition } from "../../core/transformer"
 import {
   fixtures,
   fixturesPath,
@@ -456,6 +457,22 @@ suite("routerResolver", () => {
       assert.ok(mountedChild?.router.type !== "APIRouter")
     })
 
+    test("does not display an empty non-router include assignment", async () => {
+      const result = await buildRouterGraph(
+        fixtures.inferenceBoundaries.mainPy,
+        parser,
+        fixtures.inferenceBoundaries.root,
+        nodeFileSystem,
+      )
+
+      assert.ok(result)
+      const app = routerNodeToAppDefinition(
+        result,
+        fixtures.inferenceBoundaries.root,
+      )
+      assert.ok(app.routers.every((router) => router.name !== "not_router"))
+    })
+
     test("merges tags from include_router call with router tags", async () => {
       const result = await buildRouterGraph(
         fixtures.standard.mainPy,
@@ -704,6 +721,8 @@ suite("routerResolver", () => {
         (child) => child.router.variableName === "router",
       )?.router
       assert.ok(router)
+      assert.strictEqual(router.prefix, "/service")
+      assert.deepStrictEqual(router.tags, ["service"])
       assert.ok(router.routes.some((route) => route.path === "/items"))
     })
 

--- a/src/test/core/routerResolver.test.ts
+++ b/src/test/core/routerResolver.test.ts
@@ -441,6 +441,21 @@ suite("routerResolver", () => {
       assert.strictEqual(mountChild.router.type, "FastAPI")
     })
 
+    test("does not infer an APIRouter for a mounted call assignment", async () => {
+      const result = await buildRouterGraph(
+        fixtures.inferenceBoundaries.mainPy,
+        parser,
+        fixtures.inferenceBoundaries.root,
+        nodeFileSystem,
+      )
+
+      assert.ok(result)
+      const mountedChild = result.children.find(
+        (child) => child.prefix === "/mounted",
+      )
+      assert.ok(mountedChild?.router.type !== "APIRouter")
+    })
+
     test("merges tags from include_router call with router tags", async () => {
       const result = await buildRouterGraph(
         fixtures.standard.mainPy,
@@ -674,6 +689,22 @@ suite("routerResolver", () => {
       const methods = adminRouter.routes.map((r) => r.method.toLowerCase())
       assert.ok(methods.includes("get"))
       assert.ok(methods.includes("post"))
+    })
+
+    test("resolves a router instantiated from an imported APIRouter subclass", async () => {
+      const result = await buildRouterGraph(
+        fixtures.customRouter.mainPy,
+        parser,
+        fixtures.customRouter.root,
+        nodeFileSystem,
+      )
+
+      assert.ok(result)
+      const router = result.children.find(
+        (child) => child.router.variableName === "router",
+      )?.router
+      assert.ok(router)
+      assert.ok(router.routes.some((route) => route.path === "/items"))
     })
 
     test("resolves aliased FastAPI and APIRouter class imports", async () => {

--- a/src/test/fixtures/custom-router/auth/testing_router.py
+++ b/src/test/fixtures/custom-router/auth/testing_router.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+
+
+class ProtectedRouter(APIRouter):
+    pass

--- a/src/test/fixtures/custom-router/main.py
+++ b/src/test/fixtures/custom-router/main.py
@@ -1,0 +1,5 @@
+from fastapi import FastAPI
+from services.test import test_service
+
+app = FastAPI()
+app.include_router(test_service.router)

--- a/src/test/fixtures/custom-router/services/test/test_service.py
+++ b/src/test/fixtures/custom-router/services/test/test_service.py
@@ -1,6 +1,6 @@
 from auth.testing_router import ProtectedRouter
 
-router = ProtectedRouter()
+router = ProtectedRouter(prefix="/service", tags=["service"])
 
 
 @router.get("/items")

--- a/src/test/fixtures/custom-router/services/test/test_service.py
+++ b/src/test/fixtures/custom-router/services/test/test_service.py
@@ -1,0 +1,8 @@
+from auth.testing_router import ProtectedRouter
+
+router = ProtectedRouter()
+
+
+@router.get("/items")
+def list_items():
+    return []

--- a/src/test/fixtures/inference-boundaries/main.py
+++ b/src/test/fixtures/inference-boundaries/main.py
@@ -1,0 +1,6 @@
+from fastapi import FastAPI
+
+import subapp
+
+app = FastAPI()
+app.mount("/mounted", subapp.app)

--- a/src/test/fixtures/inference-boundaries/main.py
+++ b/src/test/fixtures/inference-boundaries/main.py
@@ -3,4 +3,5 @@ from fastapi import FastAPI
 import subapp
 
 app = FastAPI()
+app.include_router(subapp.not_router)
 app.mount("/mounted", subapp.app)

--- a/src/test/fixtures/inference-boundaries/subapp.py
+++ b/src/test/fixtures/inference-boundaries/subapp.py
@@ -1,0 +1,8 @@
+from fastapi import FastAPI
+
+
+def create_app():
+    return FastAPI()
+
+
+app = create_app()

--- a/src/test/fixtures/inference-boundaries/subapp.py
+++ b/src/test/fixtures/inference-boundaries/subapp.py
@@ -6,3 +6,4 @@ def create_app():
 
 
 app = create_app()
+not_router = object()

--- a/src/test/testUtils.ts
+++ b/src/test/testUtils.ts
@@ -43,6 +43,10 @@ export const fixtures = {
     root: uri(join(fixturesPath, "custom-subclass")),
     mainPy: uri(join(fixturesPath, "custom-subclass", "main.py")),
   },
+  customRouter: {
+    root: uri(join(fixturesPath, "custom-router")),
+    mainPy: uri(join(fixturesPath, "custom-router", "main.py")),
+  },
   errorCases: {
     root: uri(join(fixturesPath, "error-cases")),
     mainPy: uri(join(fixturesPath, "error-cases", "main.py")),
@@ -55,6 +59,10 @@ export const fixtures = {
   flat: {
     root: uri(join(fixturesPath, "flat")),
     mainPy: uri(join(fixturesPath, "flat", "main.py")),
+  },
+  inferenceBoundaries: {
+    root: uri(join(fixturesPath, "inference-boundaries")),
+    mainPy: uri(join(fixturesPath, "inference-boundaries", "main.py")),
   },
   monorepo: {
     workspaceRoot: uri(join(fixturesPath, "monorepo")),


### PR DESCRIPTION
Closes #217

This PR fixes a bug where the Path Operation Explorer could find routes decorated on a router instantiated from an imported `APIRouter` subclass, but it could not recognize the router assignment itself. This prevented the router node, and therefore its routes, from being added to the tree view.

With this change, the analyzer records top-level router candidates even when their constructors are imported and cannot be recognized locally. When the resolver follows a module-qualified reference, it can use the corresponding router assignment to construct the missing router node.

See the [`custom-router` fixture](https://github.com/fastapi/fastapi-vscode/tree/fix/issue-217-imported-router/src/test/fixtures/custom-router) as an example.