### PR TITLE
🐛 Stop overriding the default Explorer shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The Path Operation Explorer provides a hierarchical tree view of all FastAPI rou
 
 ### Search for routes
 
-Using ctrl+shift+E (cmd+shift+E on Mac), you can open the Command Palette and quickly search for routes by path, method, or name.
+Use the search button in the Path Operation Explorer, or run **FastAPI: Search Path Operations...** from the Command Palette, to quickly search for routes by path, method, or name.
 
 ![Search Routes GIF](media/walkthrough/search.gif)
 
@@ -53,4 +53,3 @@ The FastAPI extension collects anonymous usage data and sends it to FastAPI to h
 
 ## License 
 MIT
-

--- a/package.json
+++ b/package.json
@@ -114,13 +114,6 @@
         "category": "FastAPI Cloud"
       }
     ],
-    "keybindings": [
-      {
-        "command": "fastapi-vscode.searchPathOperations",
-        "key": "ctrl+shift+e",
-        "mac": "cmd+shift+e"
-      }
-    ],
     "menus": {
       "commandPalette": [
         {
@@ -158,14 +151,19 @@
       ],
       "view/title": [
         {
-          "command": "fastapi-vscode.refreshPathOperations",
+          "command": "fastapi-vscode.searchPathOperations",
           "when": "view == path-operation-explorer",
           "group": "navigation@1"
         },
         {
-          "command": "fastapi-vscode.toggleRouters",
+          "command": "fastapi-vscode.refreshPathOperations",
           "when": "view == path-operation-explorer",
           "group": "navigation@2"
+        },
+        {
+          "command": "fastapi-vscode.toggleRouters",
+          "when": "view == path-operation-explorer",
+          "group": "navigation@3"
         }
       ],
       "view/item/context": [
@@ -242,7 +240,7 @@
           {
             "id": "search-path-operations",
             "title": "Quickly Find Path Operations",
-            "description": "Instantly filter and navigate to any path operation in your application.\n[Search Path Operations](command:fastapi-vscode.searchPathOperations)",
+            "description": "Use the search button in the Path Operation Explorer to instantly filter and navigate to any path operation in your application.\n[Search Path Operations](command:fastapi-vscode.searchPathOperations)",
             "media": {
               "image": "media/walkthrough/search.gif",
               "altText": "Search path operations quick pick showing filtered results"


### PR DESCRIPTION
This PR removes the default keybinding for path operation search, restoring VS Code’s built-in Explorer shortcut, and adds a search action to the Path Operation Explorer header.

Users can still assign their preferred shortcut to `FastAPI: Search Path Operations...` through VS Code’s Keyboard Shortcuts editor.

Closes #227